### PR TITLE
open-webui integration (fixes#42)

### DIFF
--- a/index.html
+++ b/index.html
@@ -944,7 +944,7 @@
           
           // Try URL parameter approach for Open WebUI
           const encodedPrompt = encodeURIComponent(cleanPrompt);
-          const webUIUrl = `${WEBUI_URL}/?q=${encodedPrompt}`;
+          const webUIUrl = `${WEBUI_URL}?q=${encodedPrompt}`;
           
           const newWindow = window.open(webUIUrl, '_blank', 'noopener,noreferrer');
           


### PR DESCRIPTION
`Try it now` button feeds the prompt to open-webui and submits it. 

<img width="325" height="177" alt="image" src="https://github.com/user-attachments/assets/ffbe67c5-e47f-4c44-b268-07abb272735a" />
