### PR TITLE
smoother help text (fixes #74)

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
         </div>
         <span id="userDisplay" style="display:none; font-size:11px; color:var(--muted);">          <strong id="userName" style="cursor:pointer; text-decoration:underline;" title="Click to manage Jules API key"></strong>
         </span>
+        <a href="https://github.com/ole-vi/prompt-sharing/blob/main/README.md" target="_blank" rel="noopener" class="help-link" title="View documentation" style="padding:6px 10px; font-size:12px;">📖 Help</a>
       </div>
     </div>
   </header>
@@ -80,13 +81,12 @@
       <input id="search" placeholder="Search prompts..." />
       <button class="btn" id="freeInputBtn" title="Send a custom prompt to Jules">✏️ Free Input to Jules</button>
       <div id="list"></div>
-      <div style="padding:8px 6px; color:var(--muted); font-size:12px;">
-        Add prompts by committing <code>.md</code> files to <code>/prompts</code> in your repo. Use a first-level heading for the title.
-      </div>
     </aside>
 
-    <main id="main" class="card">
-      <div id="empty">Select a prompt from the list. You can deep link to any prompt using the URL hash.</div>
+    <main id="main" class="card" style="display:flex; flex-direction:column;">
+      <div id="empty" style="display:flex; flex-direction:column; align-items:center; justify-content:center; flex:1; min-height:300px; color:var(--muted); font-size:16px;">
+        <span>Please select a prompt from the list.</span>
+      </div>
       <h1 id="title" style="display:none"></h1>
       <div id="meta" style="display:none"></div>
       <div id="actions" style="display:none">

--- a/src/styles.css
+++ b/src/styles.css
@@ -331,6 +331,24 @@ header {
   transform: translateY(1px);
 }
 
+.help-link {
+  text-decoration: none;
+  color: var(--muted);
+  font-size: 13px;
+  cursor: pointer;
+  padding: 6px 10px;
+  display: inline-block;
+  transition: all 0.2s;
+  border-radius: 8px;
+  border: 1px solid transparent;
+}
+
+.help-link:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(77, 217, 255, 0.1);
+}
+
 /* ===== Content ===== */
 #content {
   line-height: 1.55;


### PR DESCRIPTION
Removed the tips and added a help link that links to the readme. (top right) 

<img width="1903" height="699" alt="image" src="https://github.com/user-attachments/assets/8a943dac-574f-4710-a7e0-eef26858e0d5" />
