### PR TITLE
removed popup limit from Jules subtasks (fixes #80)

### DIFF
--- a/src/modules/jules.js
+++ b/src/modules/jules.js
@@ -696,12 +696,7 @@ async function submitSubtasks(subtasks) {
       try {
         const sessionUrl = await callRunJulesFunction(subtask.fullContent, 'myplanet');
         if (sessionUrl) {
-          if (successCount < 3) {
-            window.open(sessionUrl, '_blank', 'noopener,noreferrer');
-          } else if (successCount === 3) {
-            alert(`Opening subtask ${subtask.sequenceInfo.current}. Remaining ${totalCount - successCount - 1} subtasks are queued. Check your Jules notifications.`);
-            window.open(sessionUrl, '_blank', 'noopener,noreferrer');
-          }
+          window.open(sessionUrl, '_blank', 'noopener,noreferrer');
         }
         
         successCount++;


### PR DESCRIPTION
Removed limit on opening subtask tabs - all subtasks now open in new tabs

Users may need to allow popups in their browser settings for multiple tabs to open