### PR TITLE
smoother home link (fixes #143)

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     <div id="headerContainer" style="display:flex; justify-content:space-between; align-items:center; gap:16px; padding:12px 16px; width:100%;">
       <div style="display:flex; align-items:center; gap:16px;">
         <div id="headerBranding" style="display:flex; align-items:center; gap:12px;">
-          <a href="https://ole-vi.github.io/prompt-sharing/" style="text-decoration:none; color:inherit; display:flex; align-items:center; gap:12px;">
+          <a id="logoLink" href="/" style="text-decoration:none; color:inherit; display:flex; align-items:center; gap:12px;">
             <img src="assets/PromptSyncLogo.svg" alt="PromptSync" style="width:36px; height:36px; flex-shrink:0; object-fit:contain;">
             <div>
               <div style="font-size:24px; font-weight:900; letter-spacing:0.5px; line-height:1.2;">PromptSync</div>


### PR DESCRIPTION
Made home link relative, so when testing on localhost it no longer redirects to https://ole-vi.github.io/prompt-sharing/