### PR TITLE
refactor: implement automatic tag extraction from filenames (fixes: #133)

### DIFF
--- a/src/modules/prompt-list.js
+++ b/src/modules/prompt-list.js
@@ -67,16 +67,20 @@ export function ensureAncestorsExpanded(path) {
   return changed;
 }
 
-function prettyTitle(name) {
-  const base = name.replace(/\.md$/i, "");
-  if (!PRETTY_TITLES) return base;
-  
+function generateTitleAndTags(name) {
+  const title = name.replace(/\.md$/i, "");
+  if (!PRETTY_TITLES) {
+    return { title, tags: [] };
+  }
+
+  const tags = [];
   for (const [key, { emoji, keywords }] of Object.entries(EMOJI_PATTERNS)) {
-    if (keywords.some(kw => new RegExp(kw, 'i').test(base))) {
-      return emoji + " " + base;
+    if (keywords.some(kw => new RegExp(kw, 'i').test(title))) {
+      tags.push({ key, emoji });
     }
   }
-  return base;
+
+  return { title, tags };
 }
 
 function getExpandedStateKey(owner, repo, branch) {
@@ -349,10 +353,26 @@ function renderTree(node, container, forcedExpanded, owner, repo, branch) {
       left.style.display = 'flex';
       left.style.flexDirection = 'column';
       left.style.gap = '2px';
+
+      const { title, tags } = generateTitleAndTags(file.name);
+
       const t = document.createElement('div');
       t.className = 'item-title';
-      t.textContent = prettyTitle(file.name);
+      t.textContent = title;
       left.appendChild(t);
+
+      if (tags.length > 0) {
+        const tagsContainer = document.createElement('div');
+        tagsContainer.className = 'tags-container';
+        tags.forEach(tag => {
+          const tagEl = document.createElement('span');
+          tagEl.className = `tag tag-${tag.key}`;
+          tagEl.textContent = `${tag.emoji} ${tag.key}`;
+          tagsContainer.appendChild(tagEl);
+        });
+        left.appendChild(tagsContainer);
+      }
+
       a.appendChild(left);
       li.appendChild(a);
       container.appendChild(li);

--- a/src/styles.css
+++ b/src/styles.css
@@ -280,6 +280,29 @@ header {
   box-shadow: 0 0 12px rgba(77, 217, 255, 0.2);
 }
 
+/* ===== Tags ===== */
+.tags-container {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.tag {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  text-transform: capitalize;
+}
+
+.tag-review { background: #3b82f633; color: #60a5fa; }
+.tag-bug { background: #ef444433; color: #f87171; }
+.tag-design { background: #a855f733; color: #c084fc; }
+.tag-refactor { background: #14b8a633; color: #2dd4bf; }
+
 /* ===== Main Content ===== */
 #main {
   padding: 14px;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -23,10 +23,10 @@ export const STORAGE_KEY_FAVORITE_REPOS = "jules_favorite_repos";
 
 // Emoji classification keywords
 export const EMOJI_PATTERNS = {
-  review: { emoji: "🔍", keywords: ["review", "\\bpr\\b", "rubric", "audit", "inspect", "check", "analyze", "investigation"] },
-  bug: { emoji: "🩹", keywords: ["bug", "triage", "fix", "issue", "solve", "repair", "patch", "hotfix"] },
-  design: { emoji: "📖", keywords: ["spec", "design", "plan", "explorer", "guide", "tutorial", "documentation", "readme", "onboard"] },
-  refactor: { emoji: "🧹", keywords: ["refactor", "cleanup", "sweep", "maintenance", "optimize", "improve", "reorganize", "deadcode"] }
+  review: { emoji: "🔍", keywords: ["review", "\\bpr\\b", "rubric", "audit", "inspect", "check", "analyze", "investigation", "validate", "verify", "pull-request"] },
+  bug: { emoji: "🩹", keywords: ["bug", "triage", "fix", "issue", "solve", "repair", "patch", "hotfix", "error", "defect", "glitch"] },
+  design: { emoji: "📖", keywords: ["spec", "design", "plan", "explorer", "guide", "tutorial", "documentation", "readme", "onboard", "architecture", "specification", "docs"] },
+  refactor: { emoji: "🧹", keywords: ["refactor", "cleanup", "sweep", "maintenance", "optimize", "improve", "reorganize", "deadcode", "chore", "tidy", "restructure"] }
 };
 
 // Branch classification


### PR DESCRIPTION
(fixes: #133)

This commit introduces a new feature that automatically extracts tags from filenames and displays them as "GitHub label pills" next to the prompt title in the sidebar.

Key changes:
- Modified `src/modules/prompt-list.js` to generate and display tags.
- Renamed the `prettyTitle` function to `generateTitleAndTags` to more accurately reflect its new functionality.
- Added new CSS rules to `src/styles.css` to style the tags.
- Expanded the list of keywords in `src/utils/constants.js` to improve the accuracy and usefulness of the automatic tagging.

Jules Link: https://jules.google.com/session/13796830627797531302/code/src/utils/constants.js