### PR TITLE
feat: Add folder-based tags to prompts (fixes: #149)

### DIFF
--- a/src/modules/prompt-list.js
+++ b/src/modules/prompt-list.js
@@ -353,10 +353,28 @@ function renderTree(node, container, forcedExpanded, owner, repo, branch) {
       left.style.display = 'flex';
       left.style.flexDirection = 'column';
       left.style.gap = '2px';
+
+      const titleAndTag = document.createElement('div');
+      titleAndTag.style.display = 'flex';
+      titleAndTag.style.alignItems = 'center';
+
       const t = document.createElement('div');
       t.className = 'item-title';
       t.textContent = prettyTitle(file.name);
-      left.appendChild(t);
+      titleAndTag.appendChild(t);
+
+      const parts = file.path.split('/');
+      if (parts.length > 2) {
+        const folderName = parts[parts.length - 2];
+        if (folderName) {
+          const tag = document.createElement('span');
+          tag.className = 'folder-tag';
+          tag.textContent = folderName;
+          titleAndTag.appendChild(tag);
+        }
+      }
+
+      left.appendChild(titleAndTag);
       a.appendChild(left);
       li.appendChild(a);
       container.appendChild(li);

--- a/src/styles.css
+++ b/src/styles.css
@@ -280,6 +280,17 @@ header {
   box-shadow: 0 0 12px rgba(77, 217, 255, 0.2);
 }
 
+.folder-tag {
+  background-color: var(--border);
+  color: var(--muted);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  margin-left: 8px;
+}
+
 /* ===== Main Content ===== */
 #main {
   padding: 14px;


### PR DESCRIPTION
(fixes: #149)

This commit introduces a new feature that automatically adds tags to prompts based on their parent folder.

- Extracts the parent folder name from the file path in `src/modules/prompt-list.js`.
- Creates a `<span>` element with the class `folder-tag` to display the folder name as a tag next to the prompt title.
- Adds styling for the `.folder-tag` class in `src/styles.css` to resemble a GitHub label.

Jules Link: https://jules.google.com/session/11567748341516360356/code/src/modules/prompt-list.js