### PR TITLE
smoother jules queue (fixes #185)

### DIFF
--- a/src/modules/jules.js
+++ b/src/modules/jules.js
@@ -597,50 +597,52 @@ export async function callRunJulesFunction(promptText, sourceId, branch = 'maste
     throw new Error('No repository selected');
   }
 
+  const julesBtn = document.getElementById('julesBtn');
+  const originalText = julesBtn?.textContent;
+  if (julesBtn) {
+    julesBtn.textContent = 'Running...';
+    julesBtn.disabled = true;
+  }
 
   try {
-    const julesBtn = document.getElementById('julesBtn');
-    let originalText = null;
-    if (julesBtn) {
-      originalText = julesBtn.textContent;
-      julesBtn.textContent = 'Running...';
-      julesBtn.disabled = true;
-    }
-
-    const token = await user.getIdToken(true);
-    const functionUrl = 'https://runjuleshttp-n7gaasoeoq-uc.a.run.app';
-
-    const payload = { promptText: promptText || '', sourceId: sourceId, branch: branch, title: title };
+    const sessionUrl = await runJulesAPI(promptText, sourceId, branch, title, user);
     
-    const response = await fetch(functionUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`
-      },
-      body: JSON.stringify(payload)
-    });
-
-    const result = await response.json();
-    if (!response.ok) {
-      throw new Error(result.error || `HTTP ${response.status}`);
-    }
-
-
     if (julesBtn) {
       julesBtn.textContent = originalText;
       julesBtn.disabled = false;
     }
 
-    return result.sessionUrl || null;
+    return sessionUrl;
   } catch (error) {
-    const julesBtn = document.getElementById('julesBtn');
     if (julesBtn) {
       julesBtn.textContent = '⚡ Try in Jules';
       julesBtn.disabled = false;
     }
     throw error;
   }
+}
+
+async function runJulesAPI(promptText, sourceId, branch, title, user) {
+  const token = await user.getIdToken(true);
+  const functionUrl = 'https://runjuleshttp-n7gaasoeoq-uc.a.run.app';
+
+  const payload = { promptText: promptText || '', sourceId: sourceId, branch: branch, title: title };
+  
+  const response = await fetch(functionUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    },
+    body: JSON.stringify(payload)
+  });
+
+  const result = await response.json();
+  if (!response.ok) {
+    throw new Error(result.error || `HTTP ${response.status}`);
+  }
+
+  return result.sessionUrl || null;
 }
 
 export async function handleTryInJules(promptText) {


### PR DESCRIPTION
The queue was trying to access the Try in Jules button, which was null (the button doesn't 't exist on the queue page), causing the entire queue execution to crash.

This PR refactors callRunJulesFunction by extracting pure API logic into runJulesAPI(), fixing the queue execution error that occurred when trying to access a non-existent julesBtn