### PR TITLE
smoother breakpoints (fixes #193)

### DIFF
--- a/header.html
+++ b/header.html
@@ -142,7 +142,8 @@
       color: var(--muted);
       text-decoration: none;
       transition: all 0.2s;
-      font-size: 15px;
+      font-size: 16px;
+      font-weight: 700;
     }
     
     .mobile-nav-item:hover {

--- a/src/styles.css
+++ b/src/styles.css
@@ -131,8 +131,8 @@ button.nav-item:hover {
 }
 
 .nav-label {
-  font-size: 13px;
-  font-weight: 500;
+  font-size: 16px;
+  font-weight: 700;
   letter-spacing: 0.2px;
   display: inline-block;
 }
@@ -159,7 +159,9 @@ button.nav-item:hover {
   }
   
   .nav-label {
-    font-size: 10px;
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 0.2px;
   }
 }
 
@@ -174,7 +176,9 @@ button.nav-item:hover {
   }
   
   .nav-label {
-    font-size: 9px;
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 0.2px;
   }
 }
 


### PR DESCRIPTION
>=1000px:
<img width="1021" height="691" alt="image" src="https://github.com/user-attachments/assets/3c358417-5468-4795-b191-d316a8df3da1" />


<1000px:
<img width="977" height="686" alt="image" src="https://github.com/user-attachments/assets/bd56054c-9888-4e35-9280-74aa86556686" />

Also fixed an issue where the header was getting cramped on mobile due to conflicting css (still requires cleanup in a future refactor). Now it still is usable on screens as small as 350px 

<img width="299" height="649" alt="image" src="https://github.com/user-attachments/assets/e6ca6a6f-ed1c-4349-a8e7-fb22952f38f3" />



