### PR TITLE
feat: Add validation layer for URL parameters

### DIFF
--- a/src/modules/github-api.js
+++ b/src/modules/github-api.js
@@ -19,8 +19,16 @@ export async function fetchJSON(url) {
   }
 }
 
+function encodePathPreservingSlashes(path) {
+  return String(path)
+    .split('/')
+    .map(segment => encodeURIComponent(segment))
+    .join('/');
+}
+
 export async function listPromptsViaContents(owner, repo, branch, path = 'prompts') {
-  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${path}?ref=${encodeURIComponent(branch)}&ts=${Date.now()}`;
+  const encodedPath = encodePathPreservingSlashes(path);
+  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodedPath}?ref=${encodeURIComponent(branch)}&ts=${Date.now()}`;
   const entries = await fetchJSON(url);
   if (!Array.isArray(entries)) return [];
 
@@ -56,7 +64,8 @@ export async function listPromptsViaTrees(owner, repo, branch, path = 'prompts')
 }
 
 export async function fetchRawFile(owner, repo, branch, path) {
-  const url = `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(branch)}/${path}?ts=${Date.now()}`;
+  const encodedPath = encodePathPreservingSlashes(path);
+  const url = `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(branch)}/${encodedPath}?ts=${Date.now()}`;
   const res = await fetch(url, { cache: 'no-store' });
   if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
   return res.text();

--- a/src/utils/url-params.js
+++ b/src/utils/url-params.js
@@ -20,7 +20,8 @@ export function parseParams() {
     const p = new URLSearchParams(src);
     for (const [k, v] of p.entries()) {
       const key = k.toLowerCase();
-      const value = decodeURIComponent(v);
+      // URLSearchParams values are already decoded.
+      const value = v;
 
       const validator = validationMap[key];
       if (validator) {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -17,8 +17,8 @@ export function validateRepo(repo) {
     return false;
   }
   // Alphanumeric characters, hyphens, underscores, and periods
-  // Cannot be '.' or '..', cannot end with '.git'
-  const validRepoRegex = /^(?!^\.$)(?!^\.\.$)(?!.*\.git$)[a-zA-Z0-9_.-]+$/;
+  // Cannot be '.' or '..'
+  const validRepoRegex = /^(?!^\.$)(?!^\.\.$)[a-zA-Z0-9_.-]+$/;
   return validRepoRegex.test(repo);
 }
 


### PR DESCRIPTION
Adds a validation layer for the owner, repo, and branch URL parameters.

- Defines allowed characters and length limits for owner, repo, and branch params based on GitHub and Git naming conventions.
- Creates src/utils/validation.js with validateOwner, validateRepo, and validateBranch functions.
- Updates parseParams in src/utils/url-params.js to validate and sanitize parameters before returning them. Invalid parameters are discarded, allowing the app to fall back to default values.
- Ensures that all parameters used in API calls in src/modules/github-api.js are properly URL-encoded using encodeURIComponent.

---
https://jules.google.com/session/9498111517676909308