### PR TITLE
refactor(dom-helpers): Use class toggle for setElementDisplay

### DIFF
--- a/src/utils/dom-helpers.js
+++ b/src/utils/dom-helpers.js
@@ -7,8 +7,15 @@ export function createElement(tag, className = '', textContent = '') {
   return el;
 }
 
+/**
+ * Toggles the visibility of an element by adding or removing the '.hidden' class.
+ * Note: This relies on a global '.hidden' class with 'display: none !important;'.
+ * @param {HTMLElement} el The element to show or hide.
+ * @param {boolean} show If true, the element will be shown; otherwise, it will be hidden.
+ * @deprecated Consider using `element.classList.toggle('hidden', !show)` directly for clarity.
+ */
 export function setElementDisplay(el, show = true) {
-  el.style.display = show ? '' : 'none';
+  el.classList.toggle('hidden', !show);
 }
 
 export function toggleClass(el, className, force) {


### PR DESCRIPTION
Updated `setElementDisplay()` to use `element.classList.toggle('hidden', !show)` instead of directly manipulating `el.style.display`.

This change promotes a better practice of separating concerns by using a CSS class for visibility state. It relies on the existing `.hidden` utility class in `base.css`.

- Refactored `setElementDisplay` in `src/utils/dom-helpers.js`.
- Added a JSDoc comment explaining the new class-based approach and deprecating the function in favor of direct `classList` usage.
- Verified that all callers of the function target block-level elements and are not negatively affected by this change.

---
https://jules.google.com/session/17085588763375585116