### PR TITLE
refactor: Centralize magic numbers in constants.js

### DIFF
--- a/src/modules/jules-api.js
+++ b/src/modules/jules-api.js
@@ -1,7 +1,7 @@
 // ===== Jules API Client Module =====
 // Provides access to the Jules API for managing sources, sessions, and activities
 
-import { JULES_API_BASE, ERRORS } from '../utils/constants.js';
+import { JULES_API_BASE, ERRORS, PAGE_SIZES } from '../utils/constants.js';
 
 export async function getDecryptedJulesKey(uid) {
   try {
@@ -81,10 +81,10 @@ export async function getJulesSourceDetails(apiKey, sourceId) {
   }
 }
 
-export async function listJulesSessions(apiKey, pageSize = 10, pageToken = null) {
+export async function listJulesSessions(apiKey, pageToken = null) {
   try {
     const url = new URL(`${JULES_API_BASE}/sessions`);
-    url.searchParams.set('pageSize', pageSize.toString());
+    url.searchParams.set('pageSize', PAGE_SIZES.julesSessions.toString());
     if (pageToken) {
       url.searchParams.set('pageToken', pageToken);
     }
@@ -200,7 +200,7 @@ export async function loadJulesProfileInfo(uid) {
     // Fetch sources and sessions in parallel
     const [sourcesData, sessionsData] = await Promise.all([
       listJulesSources(apiKey),
-      listJulesSessions(apiKey, 10)
+      listJulesSessions(apiKey)
     ]);
 
     // Fetch branch details for each source

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -75,3 +75,63 @@ export const UI_TEXT = {
   RUNNING: "Running...",
   SAVE_KEY: "Save & Continue"
 };
+
+/**
+ * @typedef {object} RetryConfig
+ * @property {number} maxRetries - The maximum number of retries.
+ * @property {number} baseDelay - The base delay in milliseconds for exponential backoff.
+ */
+
+/**
+ * Configuration for retry logic.
+ * @type {RetryConfig}
+ */
+export const RETRY_CONFIG = {
+  maxRetries: 3,
+  baseDelay: 1000
+};
+
+/**
+ * @typedef {object} Timeouts
+ * @property {number} statusBar - The duration in milliseconds to display a status bar message.
+ * @property {number} fetch - The timeout in milliseconds for fetch requests.
+ */
+
+/**
+ * Timeouts for various UI and network operations.
+ * @type {Timeouts}
+ */
+export const TIMEOUTS = {
+  statusBar: 3000,
+  fetch: 5000
+};
+
+/**
+ * @typedef {object} PageSizes
+ * @property {number} julesSessions - The number of Jules sessions to fetch per page.
+ * @property {number} branches - The number of branches to fetch per page.
+ */
+
+/**
+ * Page sizes for paginated API calls.
+ * @type {PageSizes}
+ */
+export const PAGE_SIZES = {
+  julesSessions: 10,
+  branches: 100
+};
+
+/**
+ * @typedef {object} CacheDurations
+ * @property {number} short - The duration in milliseconds for short-lived cache items.
+ * @property {number} session - A flag indicating that the cache item should last for the session.
+ */
+
+/**
+ * Cache durations for various data types.
+ * @type {CacheDurations}
+ */
+export const CACHE_DURATIONS = {
+  short: 300000, // 5 minutes
+  session: 0
+};

--- a/src/utils/session-cache.js
+++ b/src/utils/session-cache.js
@@ -1,4 +1,6 @@
 // Session storage cache utilities
+import { CACHE_DURATIONS } from './constants.js';
+
 const CACHE_KEYS = {
   JULES_ACCOUNT: 'jules_account_info',
   JULES_SESSIONS: 'jules_sessions',
@@ -10,12 +12,12 @@ const CACHE_KEYS = {
   USER_PROFILE: 'user_profile'
 };
 
-// Optional cache durations (set to null for session-only caching)
-const CACHE_DURATION = {
-  JULES_ACCOUNT: null, // Cache for entire session
-  QUEUE_ITEMS: null,   // Cache until modified (we invalidate on changes)
-  BRANCHES: null,      // Cache until branch change
-  DEFAULT: 5 * 60 * 1000 // 5 minutes fallback
+// Map keys to specific cache durations
+const KEY_DURATIONS = {
+  JULES_ACCOUNT: CACHE_DURATIONS.session,
+  QUEUE_ITEMS: CACHE_DURATIONS.session,
+  BRANCHES: CACHE_DURATIONS.session,
+  DEFAULT: CACHE_DURATIONS.short
 };
 
 function getCacheKey(key, userId) {
@@ -43,15 +45,13 @@ export function getCache(key, userId = null) {
 
     const { data, timestamp } = JSON.parse(cached);
     
-    // Check if this key has a duration limit
-    const duration = CACHE_DURATION[key] || CACHE_DURATION.DEFAULT;
+    const duration = KEY_DURATIONS[key] || KEY_DURATIONS.DEFAULT;
     
-    // If duration is null, cache for entire session (no expiration)
-    if (duration === null) {
+    // A duration of 0 means session-only cache
+    if (duration === CACHE_DURATIONS.session) {
       return data;
     }
     
-    // Otherwise check expiration
     const age = Date.now() - timestamp;
     if (age < duration) {
       return data;


### PR DESCRIPTION
Adds RETRY_CONFIG, TIMEOUTS, PAGE_SIZES, and CACHE_DURATIONS to constants.js and updates session-cache.js, jules-modal.js, and jules-api.js to use them. This improves maintainability by centralizing configuration and removing hardcoded values.

---
https://jules.google.com/session/4265430144496330174