### PR TITLE
refactor: Use CSS class for modal visibility

### DIFF
--- a/src/modules/jules-modal.js
+++ b/src/modules/jules-modal.js
@@ -36,7 +36,7 @@ export function showJulesKeyModal(onSave) {
   const modal = document.getElementById('julesKeyModal');
   const input = document.getElementById('julesKeyInput');
   
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.add('modal--visible');
   input.value = '';
   input.focus();
 
@@ -86,12 +86,12 @@ export function showJulesKeyModal(onSave) {
 
 export function hideJulesKeyModal() {
   const modal = document.getElementById('julesKeyModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.remove('modal--visible');
 }
 
 export async function showJulesEnvModal(promptText) {
   const modal = document.getElementById('julesEnvModal');
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.add('modal--visible');
 
   const submitBtn = document.getElementById('julesEnvSubmitBtn');
   const queueBtn = document.getElementById('julesEnvQueueBtn');
@@ -277,7 +277,7 @@ async function handleRepoSelect(sourceId, branch, promptText, suppressPopups = f
 
 export function hideJulesEnvModal() {
   const modal = document.getElementById('julesEnvModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.remove('modal--visible');
 }
 
 export function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error) {
@@ -301,8 +301,7 @@ export function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error) {
     messageDiv.textContent = error.message || String(error);
     detailsDiv.textContent = error.toString();
 
-    modal.style.removeProperty('display');
-    modal.style.setProperty('display', 'flex', 'important');
+    modal.classList.add('modal--visible');
 
     const handleAction = (action) => {
       retryBtn.onclick = null;
@@ -326,7 +325,7 @@ export function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error) {
 export function hideSubtaskErrorModal() {
   const modal = document.getElementById('subtaskErrorModal');
   if (modal) {
-    modal.style.removeProperty('display');
+    modal.classList.remove('modal--visible');
   }
 }
 
@@ -340,10 +339,10 @@ export function initJulesKeyModalListeners() {
 
   document.addEventListener('keydown', async (e) => {
     if (e.key === 'Escape') {
-      if (keyModal && keyModal.style.display === 'flex') {
+      if (keyModal && keyModal.classList.contains('modal--visible')) {
         hideJulesKeyModal();
       }
-      if (envModal && envModal.style.display === 'flex') {
+      if (envModal && envModal.classList.contains('modal--visible')) {
         hideJulesEnvModal();
       }
       const freeInputSection = document.getElementById('freeInputSection');
@@ -351,11 +350,11 @@ export function initJulesKeyModalListeners() {
         const { hideFreeInputForm } = await import('./jules-free-input.js');
         hideFreeInputForm();
       }
-      if (profileModal && profileModal.style.display === 'flex') {
+      if (profileModal && profileModal.classList.contains('modal--visible')) {
         const { hideUserProfileModal } = await import('./jules-profile-modal.js');
         hideUserProfileModal();
       }
-      if (sessionsHistoryModal && sessionsHistoryModal.style.display === 'flex') {
+      if (sessionsHistoryModal && sessionsHistoryModal.classList.contains('modal--visible')) {
         const { hideJulesSessionsHistoryModal } = await import('./jules-profile-modal.js');
         hideJulesSessionsHistoryModal();
       }

--- a/src/modules/jules-profile-modal.js
+++ b/src/modules/jules-profile-modal.js
@@ -19,7 +19,7 @@ export function showUserProfileModal() {
     return;
   }
 
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center; overflow-y:auto; padding:20px;');
+  modal.classList.add('modal--visible');
 
   const profileUserName = document.getElementById('profileUserName');
   const julesKeyStatus = document.getElementById('julesKeyStatus');
@@ -290,14 +290,14 @@ async function loadAndDisplayJulesProfile(uid) {
 
 export function hideUserProfileModal() {
   const modal = document.getElementById('userProfileModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center; overflow-y:auto; padding:20px;');
+  modal.classList.remove('modal--visible');
 }
 
 export function showJulesSessionsHistoryModal() {
   const modal = document.getElementById('julesSessionsHistoryModal');
   const searchInput = document.getElementById('sessionSearchInput');
   
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1002; flex-direction:column; align-items:center; justify-content:center; overflow-y:auto; padding:20px;');
+  modal.classList.add('modal--visible');
   
   allSessionsCache = [];
   sessionNextPageToken = null;
@@ -308,7 +308,7 @@ export function showJulesSessionsHistoryModal() {
 
 export function hideJulesSessionsHistoryModal() {
   const modal = document.getElementById('julesSessionsHistoryModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1002; flex-direction:column; align-items:center; justify-content:center; overflow-y:auto; padding:20px;');
+  modal.classList.remove('modal--visible');
 }
 
 async function loadSessionsPage() {

--- a/src/modules/jules-subtask-modal.js
+++ b/src/modules/jules-subtask-modal.js
@@ -34,7 +34,7 @@ export function showSubtaskSplitModal(promptText) {
   currentSubtasks = analysis.subtasks;
   
   console.log('Setting modal display to flex');
-  modal.classList.add('show');
+  modal.classList.add('modal--visible');
   console.log('Modal should now be visible');
 
   renderSplitEdit(currentSubtasks, promptText);
@@ -140,7 +140,7 @@ export function showSubtaskSplitModal(promptText) {
  */
 export function hideSubtaskSplitModal() {
   const modal = document.getElementById('subtaskSplitModal');
-  modal.classList.remove('show');
+  modal.classList.remove('modal--visible');
   currentSubtasks = [];
 }
 
@@ -216,15 +216,15 @@ function showSubtaskPreview(subtask, partNumber) {
   title.textContent = `Part ${partNumber}: ${subtask.title || `Part ${partNumber}`}`;
   content.textContent = subtask.fullContent || subtask.content || '';
   
-  modal.classList.add('show');
+  modal.classList.add('modal--visible');
   
   closeBtn.onclick = () => {
-    modal.classList.remove('show');
+    modal.classList.remove('modal--visible');
   };
   
   modal.addEventListener('click', (e) => {
     if (e.target === modal) {
-      modal.classList.remove('show');
+      modal.classList.remove('modal--visible');
     }
   });
 }

--- a/src/styles/components/modals.css
+++ b/src/styles/components/modals.css
@@ -1,6 +1,6 @@
 /* Modals & Jules Key Modal */
-#julesKeyModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1000; display: none !important; align-items: center; justify-content: center; }
-#julesKeyModal.show { display: flex !important; }
+#julesKeyModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1001; display: none !important; flex-direction: column; align-items: center; justify-content: center; }
+#julesKeyModal.show, #julesKeyModal.modal--visible { display: flex !important; }
 #julesKeyModal > div { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; max-width: 400px; width: 90%; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); }
 #julesKeyModal h2 { margin: 0 0 12px; font-size: 18px; }
 #julesKeyModal p { margin: 0 0 16px; color: var(--muted); font-size: 13px; }
@@ -9,7 +9,7 @@
 .modal-buttons { display: flex; gap: 8px; justify-content: flex-end; }
 
 .modal { display: none !important; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1000; flex-direction: column; align-items: center; justify-content: center; }
-.modal.show { display: flex !important; }
+.modal.show, .modal--visible { display: flex !important; }
 .modal-content { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; max-width: 400px; width: 90%; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); }
 .modal-content.modal-lg { max-width: 600px; max-height: 85vh; display: flex; flex-direction: column; overflow-y: auto; }
 .modal-content.modal-xl { max-width: 700px; max-height: 80vh; display: flex; flex-direction: column; overflow-y: auto; }
@@ -29,3 +29,5 @@
 
 /* Specific modal layering */
 #subtaskPreviewModal { z-index: 1002; }
+#userProfileModal { z-index: 1001; overflow-y: auto; padding: 20px; }
+#julesSessionsHistoryModal { z-index: 1002; overflow-y: auto; padding: 20px; }


### PR DESCRIPTION
Refactors the modal presentation logic to use a CSS class (`.modal--visible`) instead of inline styles for controlling visibility.

- Adds a `.modal--visible` class to `modals.css` to handle the `display` property.
- Updates all modal-related JavaScript functions (`showJulesKeyModal`, `showJulesEnvModal`, `showSubtaskErrorModal`, `showUserProfileModal`, `showJulesSessionsHistoryModal`, `showSubtaskSplitModal`, etc.) to use `classList.add('modal--visible')` and `classList.remove('modal--visible')`.
- Removes the outdated `.show` class and associated inline styles from the JavaScript, centralizing the modal visibility styling in the CSS.
- Updates the escape key listener to check for the `.modal--visible` class.

---
https://jules.google.com/session/15721964421535189035
https://jules.google.com/session/15725665392436310265