### PR TITLE
python http server alias (fixes #262)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "prompt-sharing",
+  "version": "1.0.0",
+  "description": "Prompt sharing and management application",
+  "scripts": {
+    "start": "python -m http.server 3000"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Now you can just run `npm start` instead of having to type out `python -m http.server 3000`

<img width="581" height="136" alt="image" src="https://github.com/user-attachments/assets/bee3477c-64fc-4f88-8616-e0a05481585b" />
