### PR TITLE
prompt-list performance improvement (fixes #265)

### DIFF
--- a/src/modules/prompt-list.js
+++ b/src/modules/prompt-list.js
@@ -292,7 +292,6 @@ function handleListClick(event) {
   const fileLink = target.closest('.item');
   if (fileLink) {
     event.preventDefault();
-    const slug = fileLink.dataset.slug;
     const filePath = fileLink.dataset.path;
     
     if (selectFileCallback && filePath) {


### PR DESCRIPTION
## Refactor prompt-list.js: Event Delegation & Performance Improvements

**Problem:**
- Each folder created 5+ event listeners that were never cleaned up
- New submenu DOM element created for every folder (100 folders = 100 submenus)
- Document click listener added repeatedly on every render
- Led to memory leaks and performance degradation over time

**Solution:**

**Event Delegation**
- Replaced hundreds of individual listeners with 2 delegated listeners
- One listener on `listEl` handles all list interactions (folders, files, tags)
- One listener on `document` handles submenu clicks and closes submenus
- Uses `event.target.closest()` to identify which element was clicked

**Single Reusable Submenu**
- Created one submenu element in `createSubmenu()` that gets reused for all folders
- Repositioned dynamically when opening instead of creating new ones
- Stores current folder path in `submenu.dataset.currentPath` for context

**Cleanup Function**
- Added `destroyPromptList()` to properly remove listeners and reset state
- Prevents memory leaks when re-initializing the module

**Data Attributes**
- All interactive elements use `data-action` attributes (`toggle-dir`, `open-github`, `show-submenu`)
- Makes event handling more declarative and maintainable