### PR TITLE
refactor: make prompt actions toolbar sticky (fixes: #231)

### DIFF
--- a/src/styles/components/main.css
+++ b/src/styles/components/main.css
@@ -3,7 +3,17 @@
 #empty { color: var(--muted); font-size: 14px; display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 300px; }
 #title { margin: 0 0 6px; font-size: 22px; }
 #meta { color: var(--muted); font-size: 13px; margin-bottom: 10px; }
-#actions { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 14px; }
+#actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 14px;
+  position: sticky;
+  top: 0;
+  background: var(--bg-deep);
+  padding: 10px;
+  z-index: 1;
+}
 
 /* Ensure Free Input section stacks vertically when shown */
 #freeInputSection { flex-direction: column; }


### PR DESCRIPTION
fixes: #231

Implements the suggestion from issue #231 to make the prompt actions toolbar sticky.

The following changes were made:
- Modified `src/styles/components/main.css` to add `position: sticky` to the `#actions` element.
- Added a background color and z-index to ensure the toolbar is opaque and appears above the content when scrolling.
- Added padding to the sticky element for better visual appearance.

Jules link: https://jules.google.com/session/15166900912070073038/code/src/styles/components/main.css