### PR TITLE
refactor: fetch all repositories on Jules page (fixes: #209)

### DIFF
--- a/src/modules/jules-api.js
+++ b/src/modules/jules-api.js
@@ -190,13 +190,26 @@ export async function loadJulesProfileInfo(uid) {
     throw new Error(ERRORS.JULES_KEY_REQUIRED);
   }
 
-  const [sourcesData, sessionsData] = await Promise.all([
-    listJulesSources(apiKey),
+  const fetchAllSources = async () => {
+    let allSources = [];
+    let pageToken = null;
+    do {
+      const response = await listJulesSources(apiKey, pageToken);
+      if (response.sources) {
+        allSources.push(...response.sources);
+      }
+      pageToken = response.nextPageToken;
+    } while (pageToken);
+    return allSources;
+  };
+
+  const [sources, sessionsData] = await Promise.all([
+    fetchAllSources(),
     listJulesSessions(apiKey)
   ]);
 
   return {
-    sources: sourcesData.sources || [],
+    sources,
     sessions: sessionsData.sessions || []
   };
 }


### PR DESCRIPTION
fixes: #209

The list of repositories on the Jules page was previously paginated, causing an incomplete list to be displayed. This change updates the `loadJulesProfileInfo` function to fetch all pages of repositories from the Jules API, ensuring the complete list is always shown.

The function now repeatedly calls the `listJulesSources` endpoint, using the `nextPageToken` from each response to fetch the subsequent page until all sources have been retrieved.

Jules link: https://jules.google.com/session/11008991667386207975/code/src/modules/jules-api.js