### PR TITLE
smoother submenu (fixes #322)

### DIFF
--- a/src/modules/prompt-list.js
+++ b/src/modules/prompt-list.js
@@ -170,7 +170,7 @@ function createSubmenu() {
   const makeMenuItem = (label, emoji, dataAction) => {
     const item = document.createElement('div');
     item.className = 'folder-submenu-item';
-    item.textContent = `${emoji} ${label}`;
+    item.innerHTML = `${emoji} ${label}`;
     item.dataset.action = dataAction;
     return item;
   };


### PR DESCRIPTION
fixes #322 
fixed an issue where these submenu buttons weren't rendering and were instead displaying html code.

<img width="988" height="322" alt="image" src="https://github.com/user-attachments/assets/32704df9-4af0-40af-8159-8945ed67bfaa" />
