### PR TITLE
smoother branch switching (fixes #3650

### DIFF
--- a/src/modules/prompt-renderer.js
+++ b/src/modules/prompt-renderer.js
@@ -180,7 +180,6 @@ export async function selectBySlug(slug, files, owner, repo, branch) {
     if (f) {
       await selectFile(f, false, owner, repo, branch);
     } else {
-      // If no matching file found, show free input by default
       const { showFreeInputForm } = await import('./jules-free-input.js');
       showFreeInputForm();
     }


### PR DESCRIPTION
Fixed empty content area when switching branches by displaying the free input form as a default fallback when the previously viewed prompt doesn't exist on the new branch.