### PR TITLE
smoother free input buttons (fixes #373)

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,9 +82,9 @@
         </div>
         
         <div class="actions-right">
-          <button id="freeInputSplitBtn" class="btn" title="Split into Subtasks"><span class="icon icon-inline" aria-hidden="true">content_cut</span></button>
+          <button id="freeInputSplitBtn" class="btn" title="Split into Subtasks"><span class="icon icon-inline" aria-hidden="true">content_cut</span> Split</button>
           <div class="menu-anchor">
-            <button id="freeInputCopenBtn" class="btn" title="Copy prompt and open in new tab"><span class="icon icon-inline" aria-hidden="true">open_in_new</span> ▼</button>
+            <button id="freeInputCopenBtn" class="btn" title="Copy prompt and open in new tab"><span class="icon icon-inline" aria-hidden="true">open_in_new</span> Open ▼</button>
             <div id="freeInputCopenMenu" class="menu-panel menu-panel-sm menu-panel--above" style="display:none;">
               <div class="custom-dropdown-item" data-target="blank"><span class="icon icon-inline" aria-hidden="true">public</span> Blank</div>
               <div class="custom-dropdown-item" data-target="claude"><span class="icon icon-inline" aria-hidden="true">smart_toy</span> Claude</div>
@@ -93,9 +93,9 @@
               <div class="custom-dropdown-item" data-target="chatgpt"><span class="icon icon-inline" aria-hidden="true">chat</span> ChatGPT</div>
             </div>
           </div>
-          <button id="freeInputCancelBtn" class="btn">Cancel</button>
-          <button id="freeInputQueueBtn" class="btn">Queue</button>
-          <button id="freeInputSubmitBtn" class="btn primary">Submit to Jules</button>
+          <button id="freeInputCancelBtn" class="btn"><span class="icon icon-inline" aria-hidden="true">clear</span> Clear</button>
+          <button id="freeInputQueueBtn" class="btn"><span class="icon icon-inline" aria-hidden="true">schedule</span> Queue</button>
+          <button id="freeInputSubmitBtn" class="btn primary"><span class="icon icon-inline" aria-hidden="true">send</span> Submit to Jules</button>
         </div>
       </div>
       

--- a/src/modules/jules-free-input.js
+++ b/src/modules/jules-free-input.js
@@ -78,7 +78,7 @@ export function showFreeInputForm() {
   const splitBtn = document.getElementById('freeInputSplitBtn');
   const copenBtn = document.getElementById('freeInputCopenBtn');
   const cancelBtn = document.getElementById('freeInputCancelBtn');
-  const originalCopenLabel = copenBtn?.innerHTML;
+  const originalCopenLabel = '<span class="icon icon-inline" aria-hidden="true">open_in_new</span> Open ▼';
 
   textarea.value = '';
   


### PR DESCRIPTION
Re-added the labels, changed `cancel` label to `clear` for accuracy, and added mat icons to each button for consistency with https://github.com/promptroot/promptroot/pull/367

<img width="1141" height="101" alt="image" src="https://github.com/user-attachments/assets/f989a75b-bf91-4ed9-9a22-b0503d8bd26b" />
