### PR TITLE
Refactor dropdown state handling to use CSS classes and centralized listeners

### DIFF
--- a/src/modules/branch-selector.js
+++ b/src/modules/branch-selector.js
@@ -7,6 +7,7 @@ let branchSelect = null;
 let branchDropdownBtn = null;
 let branchDropdownMenu = null;
 let branchDropdown = null;
+let dropdownControl = null;
 let currentBranch = null;
 let currentOwner = null;
 let currentRepo = null;
@@ -26,7 +27,7 @@ export function initBranchSelector(owner, repo, branch) {
   }
 
   if (branchDropdownBtn && branchDropdownMenu) {
-    initDropdown(branchDropdownBtn, branchDropdownMenu, branchDropdown);
+    dropdownControl = initDropdown(branchDropdownBtn, branchDropdownMenu, branchDropdown);
   }
 }
 
@@ -270,8 +271,9 @@ export async function loadBranches() {
             branchSelect.value = b.name;
             handleBranchChange();
             // Close menu and update label
-            branchDropdownMenu.style.display = 'none';
-            branchDropdownBtn.setAttribute('aria-expanded', 'false');
+            if (dropdownControl) {
+              dropdownControl.close();
+            }
             const labelEl = document.getElementById('branchDropdownLabel');
             if (labelEl) labelEl.textContent = `${b.name}`;
           });

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -2,14 +2,14 @@ const openDropdowns = new Set();
 
 function closeAllDropdowns() {
   for (const dropdown of openDropdowns) {
-    dropdown.menu.style.display = 'none';
+    dropdown.menu.classList.remove('open');
     dropdown.btn.setAttribute('aria-expanded', 'false');
   }
   openDropdowns.clear();
 }
 
 function toggleDropdown(dropdown) {
-  const isOpen = dropdown.menu.style.display === 'block';
+  const isOpen = dropdown.menu.classList.contains('open');
   if (isOpen) {
     closeDropdown(dropdown);
   } else {
@@ -19,37 +19,56 @@ function toggleDropdown(dropdown) {
 
 function openDropdown(dropdown) {
   closeAllDropdowns();
-  dropdown.menu.style.display = 'block';
+  dropdown.menu.classList.add('open');
+  dropdown.menu.style.display = ''; // Clear inline style if present
   dropdown.btn.setAttribute('aria-expanded', 'true');
   openDropdowns.add(dropdown);
 }
 
 function closeDropdown(dropdown) {
-  dropdown.menu.style.display = 'none';
+  dropdown.menu.classList.remove('open');
   dropdown.btn.setAttribute('aria-expanded', 'false');
   openDropdowns.delete(dropdown);
 }
 
-export function initDropdown(btn, menu, container = null) {
-  if (!btn || !menu) return;
+// Centralized document click listener
+document.addEventListener('click', (e) => {
+  const toClose = [];
+  for (const dropdown of openDropdowns) {
+    // Check if click is outside the dropdown container
+    // And also check if it's not the button itself (though button click usually stops propagation)
+    // We also check if target is contained in button (e.g. icon inside button)
+    const clickedInsideContainer = dropdown.container.contains(e.target);
+    const clickedButton = dropdown.btn === e.target || dropdown.btn.contains(e.target);
 
-  const dropdownContainer = container || menu.parentNode;
-  const dropdown = { btn, menu };
-
-  btn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    toggleDropdown(dropdown);
-  });
-
-  document.addEventListener('click', (e) => {
-    if (!dropdownContainer.contains(e.target) && e.target !== btn) {
-      closeDropdown(dropdown);
+    if (!clickedInsideContainer && !clickedButton) {
+      toClose.push(dropdown);
     }
-  });
-}
+  }
+
+  toClose.forEach(d => closeDropdown(d));
+});
 
 document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') {
     closeAllDropdowns();
   }
 });
+
+export function initDropdown(btn, menu, container = null) {
+  if (!btn || !menu) return null;
+
+  const dropdownContainer = container || menu.parentNode;
+  const dropdown = { btn, menu, container: dropdownContainer };
+
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    toggleDropdown(dropdown);
+  });
+
+  return {
+    open: () => openDropdown(dropdown),
+    close: () => closeDropdown(dropdown),
+    toggle: () => toggleDropdown(dropdown)
+  };
+}

--- a/src/styles/components/dropdown.css
+++ b/src/styles/components/dropdown.css
@@ -60,3 +60,8 @@
 
 /* Generic dropdown item utility for menu items with icons */
 .dropdown-item { display: flex; align-items: center; gap: 8px; }
+
+/* State for open dropdown */
+.custom-dropdown-menu.open {
+  display: block;
+}

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -191,3 +191,8 @@ button.mobile-nav-item { border: none; background: transparent; cursor: pointer;
 #dropdownUserName { font-weight: 600; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #userDisplay { display:flex; align-items:center; justify-content:center; width:100%; height:100%; font-size:16px; }
 #headerSignIn, #headerSignOut { justify-content: center; }
+
+/* State for open user dropdown */
+.user-dropdown.open {
+  display: block;
+}


### PR DESCRIPTION
Standardizes dropdown behavior by replacing direct style manipulation with `.open` class toggling. Centralizes document click handling in `src/modules/dropdown.js` to prevent duplicate listeners. Updates `src/modules/branch-selector.js` to use the new control API. Ensures accessibility attributes are maintained.

Changes:
- Refactor `src/modules/dropdown.js` to use `.open` class and return control object.
- Update `src/modules/branch-selector.js` to use the returned control object.
- Add `.custom-dropdown-menu.open { display: block; }` to `src/styles/components/dropdown.css`.
- Add `.user-dropdown.open { display: block; }` to `src/styles/components/header.css` to fix regression.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/d309da6d-06ff-4f10-9bd9-fb21b46164f1" />

---
https://jules.google.com/session/10570672605715204753