### PR TITLE
Refactor prompt list DOM construction to match style guidelines

### DIFF
--- a/src/styles/components/list.css
+++ b/src/styles/components/list.css
@@ -5,3 +5,8 @@
 .item-title:hover { text-decoration: underline; text-decoration-color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 3px; }
 .item-meta { color: var(--muted); font-size: 12px; }
 .item.active { border-color: var(--accent); background: linear-gradient(135deg, rgba(77,217,255,0.2), rgba(77,217,255,0.08)); box-shadow: 0 0 12px rgba(77, 217, 255, 0.2); }
+
+.list-message {
+  color: var(--muted);
+  padding: 8px;
+}

--- a/src/styles/components/tree.css
+++ b/src/styles/components/tree.css
@@ -37,8 +37,17 @@
   color: var(--text);
   background-color: transparent;
   transition: background-color 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .folder-submenu-item:hover {
   background-color: #1a1f35;
+}
+
+.file-item-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }


### PR DESCRIPTION
- Replaced `innerHTML` with `document.createElement` in `src/modules/prompt-list.js` for better security and performance.
- Moved inline styles for file items and list layout to `src/styles/components/tree.css` and `src/styles/components/list.css`.
- Introduced `.file-item-wrapper`, `.tree-child-list`, and `.list-message` CSS classes.
- Updated `makeMenuItem`, `renderTree`, `renderList`, and `loadList` to use the new DOM construction methods and classes.
- Verified changes with Playwright script and manual inspection.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/fcc1a466-f2dc-43e6-9e6e-1c17b36be018" />

---
https://jules.google.com/session/8237020206351869033