### PR TITLE
Refactor status-bar.js to use named exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "prompt-sharing",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "prompt-sharing",
+      "version": "1.0.0",
+      "license": "AGPL-3.0-only",
+      "devDependencies": {
+        "@playwright/test": "^1.57.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "AGPL-3.0-only"
+  "license": "AGPL-3.0-only",
+  "devDependencies": {
+    "@playwright/test": "^1.57.0"
+  }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -4,7 +4,7 @@ import { OWNER, REPO, BRANCH, STORAGE_KEYS } from './utils/constants.js';
 import { parseParams, getHashParam } from './utils/url-params.js';
 import { initJulesKeyModalListeners } from './modules/jules-modal.js';
 import { handleTryInJules } from './modules/jules-api.js';
-import statusBar from './modules/status-bar.js';
+import * as statusBar from './modules/status-bar.js';
 import { initPromptList, loadList, loadExpandedState, renderList, setSelectFileCallback, setRepoContext } from './modules/prompt-list.js';
 import { initPromptRenderer, selectBySlug, selectFile, setHandleTryInJulesCallback } from './modules/prompt-renderer.js';
 import { setCurrentBranch, setCurrentRepo, loadBranchFromStorage } from './modules/branch-selector.js';

--- a/src/modules/jules-queue.js
+++ b/src/modules/jules-queue.js
@@ -1,5 +1,5 @@
 import { extractTitleFromPrompt } from '../utils/title.js';
-import statusBar from './status-bar.js';
+import * as statusBar from './status-bar.js';
 import { getCache, setCache, CACHE_KEYS } from '../utils/session-cache.js';
 import { RepoSelector, BranchSelector } from './repo-branch-selector.js';
 import { showToast } from './toast.js';

--- a/src/modules/jules-subtask-modal.js
+++ b/src/modules/jules-subtask-modal.js
@@ -11,7 +11,7 @@ import { callRunJulesFunction } from './jules-api.js';
 import { showToast } from './toast.js';
 import { showConfirm } from './confirm-modal.js';
 import { extractTitleFromPrompt } from '../utils/title.js';
-import statusBar from './status-bar.js';
+import * as statusBar from './status-bar.js';
 import { JULES_MESSAGES } from '../utils/constants.js';
 
 // Module state

--- a/src/modules/status-bar.js
+++ b/src/modules/status-bar.js
@@ -1,103 +1,97 @@
 // ===== Status Bar Module =====
 
-class StatusBar {
-  constructor() {
-    this.element = null;
-    this.msgElement = null;
-    this.progressElement = null;
-    this.actionElement = null;
-    this.currentTimeout = null;
+let element = null;
+let msgElement = null;
+let progressElement = null;
+let actionElement = null;
+let closeElement = null;
+let currentTimeout = null;
+
+export function init() {
+  element = document.getElementById('statusBar');
+  if (!element) {
+    return;
   }
 
-  init() {
-    this.element = document.getElementById('statusBar');
-    if (!this.element) {
-      return;
-    }
-    
-    this.msgElement = this.element.querySelector('.status-msg');
-    this.progressElement = this.element.querySelector('.status-progress');
-    this.actionElement = this.element.querySelector('.status-action');
-    this.closeElement = this.element.querySelector('.status-close');
-    
-    // Ensure status bar is hidden initially
-    this.element.classList.remove('status-visible');
-    
-    // Add close button handler
-    if (this.closeElement) {
-      this.closeElement.addEventListener('click', () => {
-        this.clear();
-      });
-    }
-  }
+  msgElement = element.querySelector('.status-msg');
+  progressElement = element.querySelector('.status-progress');
+  actionElement = element.querySelector('.status-action');
+  closeElement = element.querySelector('.status-close');
 
-  showMessage(message, options = {}) {
-    if (!this.element || !this.msgElement) return;
+  // Ensure status bar is hidden initially
+  element.classList.remove('status-visible');
 
-    const { timeout = 3000 } = options;
-
-    this.msgElement.textContent = message;
-    this.element.classList.add('status-visible');
-    this.element.classList.remove('hidden');
-
-    if (this.currentTimeout) {
-      clearTimeout(this.currentTimeout);
-      this.currentTimeout = null;
-    }
-
-    if (timeout > 0) {
-      this.currentTimeout = setTimeout(() => {
-        this.hide();
-      }, timeout);
-    }
-  }
-
-  setProgress(text, percent) {
-    if (!this.progressElement) return;
-
-    this.progressElement.textContent = text;
-    this.progressElement.classList.remove('hidden');
-  }
-
-  clearProgress() {
-    if (!this.progressElement) return;
-    this.progressElement.textContent = '';
-    this.progressElement.classList.add('hidden');
-  }
-
-  setAction(label, callback) {
-    if (!this.actionElement) return;
-
-    this.actionElement.textContent = label;
-    this.actionElement.classList.remove('hidden');
-    this.actionElement.onclick = callback;
-  }
-
-  clearAction() {
-    if (!this.actionElement) return;
-    this.actionElement.textContent = '';
-    this.actionElement.classList.add('hidden');
-    this.actionElement.onclick = null;
-  }
-
-  hide() {
-    if (!this.element) return;
-    
-    this.element.classList.remove('status-visible');
-    this.element.classList.add('hidden');
-    
-    if (this.currentTimeout) {
-      clearTimeout(this.currentTimeout);
-      this.currentTimeout = null;
-    }
-  }
-
-  clear() {
-    this.clearProgress();
-    this.clearAction();
-    this.hide();
+  // Add close button handler
+  if (closeElement) {
+    closeElement.addEventListener('click', () => {
+      clear();
+    });
   }
 }
 
-const statusBar = new StatusBar();
-export default statusBar;
+export function showMessage(message, options = {}) {
+  if (!element || !msgElement) return;
+
+  const { timeout = 3000 } = options;
+
+  msgElement.textContent = message;
+  element.classList.add('status-visible');
+  element.classList.remove('hidden');
+
+  if (currentTimeout) {
+    clearTimeout(currentTimeout);
+    currentTimeout = null;
+  }
+
+  if (timeout > 0) {
+    currentTimeout = setTimeout(() => {
+      hide();
+    }, timeout);
+  }
+}
+
+export function setProgress(text, percent) {
+  if (!progressElement) return;
+
+  progressElement.textContent = text;
+  progressElement.classList.remove('hidden');
+}
+
+export function clearProgress() {
+  if (!progressElement) return;
+  progressElement.textContent = '';
+  progressElement.classList.add('hidden');
+}
+
+export function setAction(label, callback) {
+  if (!actionElement) return;
+
+  actionElement.textContent = label;
+  actionElement.classList.remove('hidden');
+  actionElement.onclick = callback;
+}
+
+export function clearAction() {
+  if (!actionElement) return;
+  actionElement.textContent = '';
+  actionElement.classList.add('hidden');
+  actionElement.onclick = null;
+}
+
+export function hide() {
+  if (!element) return;
+
+  element.classList.remove('status-visible');
+  element.classList.add('hidden');
+
+  if (currentTimeout) {
+    clearTimeout(currentTimeout);
+    currentTimeout = null;
+  }
+}
+
+export function clear() {
+  clearProgress();
+  clearAction();
+  hide();
+}

--- a/src/shared-init.js
+++ b/src/shared-init.js
@@ -6,7 +6,7 @@ import { initAuthStateListener } from './modules/auth.js';
 import { initBranchSelector, loadBranches, loadBranchFromStorage } from './modules/branch-selector.js';
 import { OWNER, REPO, BRANCH } from './utils/constants.js';
 import { parseParams } from './utils/url-params.js';
-import statusBar from './modules/status-bar.js';
+import * as statusBar from './modules/status-bar.js';
 
 let isInitialized = false;
 

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
Refactored `src/modules/status-bar.js` to use named exports instead of a default export of a singleton class. This simplifies the module structure and aligns with ES module best practices.
Updated imports in `src/modules/jules-subtask-modal.js`, `src/modules/jules-queue.js`, `src/app.js`, and `src/shared-init.js` to use `import * as statusBar` to maintain compatibility with the existing calling code (e.g. `statusBar.showMessage`).
Verified functionality with Playwright tests covering initialization, message display, progress updates, and actions.
Frontend verification confirmed that the status bar renders and functions correctly.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/29984a20-a820-4782-96d4-8bb517535e77" />

---
https://jules.google.com/session/9375769347562292509