### PR TITLE
Extract Reusable waitForComponents Utility

### DIFF
--- a/src/pages/index-page.js
+++ b/src/pages/index-page.js
@@ -6,6 +6,7 @@
 import { initApp } from '../app.js';
 import { initMutualExclusivity } from '../utils/checkbox-helpers.js';
 import { loadSubtaskErrorModal } from '../modules/jules-modal.js';
+import { waitForComponents } from '../shared-init.js';
 
 // Initialize all mutually exclusive checkboxes defined by data-exclusive-group attributes
 initMutualExclusivity();
@@ -14,16 +15,13 @@ initMutualExclusivity();
 loadSubtaskErrorModal();
 
 // Wait for shared components to load, then initialize app
-function waitForComponents() {
-  if (document.querySelector('header')) {
-    initApp();
-  } else {
-    setTimeout(waitForComponents, 50);
-  }
+async function startApp() {
+  await waitForComponents();
+  initApp();
 }
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', waitForComponents);
+  document.addEventListener('DOMContentLoaded', startApp);
 } else {
-  waitForComponents();
+  startApp();
 }

--- a/src/pages/jules-page.js
+++ b/src/pages/jules-page.js
@@ -3,19 +3,16 @@
  * Handles Jules account page functionality
  */
 
-import { waitForFirebase } from '../shared-init.js';
+import { waitForFirebase, waitForComponents } from '../shared-init.js';
 import { loadJulesAccountInfo } from '../modules/jules-account.js';
 import { showJulesKeyModal } from '../modules/jules-modal.js';
 import { deleteStoredJulesKey, checkJulesKey } from '../modules/jules-keys.js';
 import { showToast } from '../modules/toast.js';
 import { showConfirm } from '../modules/confirm-modal.js';
 
-function waitForComponents() {
-  if (document.querySelector('header')) {
-    initApp();
-  } else {
-    setTimeout(waitForComponents, 50);
-  }
+async function startApp() {
+  await waitForComponents();
+  initApp();
 }
 
 async function loadJulesInfo() {
@@ -165,7 +162,7 @@ function initApp() {
 }
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', waitForComponents);
+  document.addEventListener('DOMContentLoaded', startApp);
 } else {
-  waitForComponents();
+  startApp();
 }

--- a/src/pages/profile-page.js
+++ b/src/pages/profile-page.js
@@ -3,15 +3,12 @@
  * Handles user profile page functionality
  */
 
-import { waitForFirebase } from '../shared-init.js';
+import { waitForFirebase, waitForComponents } from '../shared-init.js';
 import { loadProfileDirectly } from '../modules/jules-account.js';
 
-function waitForComponents() {
-  if (document.querySelector('header')) {
-    initApp();
-  } else {
-    setTimeout(waitForComponents, 50);
-  }
+async function startApp() {
+  await waitForComponents();
+  initApp();
 }
 
 async function loadProfile() {
@@ -56,7 +53,7 @@ function initApp() {
 }
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', waitForComponents);
+  document.addEventListener('DOMContentLoaded', startApp);
 } else {
-  waitForComponents();
+  startApp();
 }

--- a/src/pages/queue-page.js
+++ b/src/pages/queue-page.js
@@ -6,6 +6,7 @@
 import { initMutualExclusivity } from '../utils/checkbox-helpers.js';
 import { attachQueueHandlers, listJulesQueue, renderQueueListDirectly } from '../modules/jules-queue.js';
 import { loadSubtaskErrorModal } from '../modules/jules-modal.js';
+import { waitForComponents } from '../shared-init.js';
 
 // Initialize checkbox mutual exclusivity
 initMutualExclusivity();
@@ -13,12 +14,9 @@ initMutualExclusivity();
 // Load the subtask error modal partial
 loadSubtaskErrorModal();
 
-function waitForComponents() {
-  if (document.querySelector('header')) {
-    initApp();
-  } else {
-    setTimeout(waitForComponents, 50);
-  }
+async function startApp() {
+  await waitForComponents();
+  initApp();
 }
 
 function initApp() {
@@ -75,7 +73,7 @@ async function loadQueue() {
 }
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', waitForComponents);
+  document.addEventListener('DOMContentLoaded', startApp);
 } else {
-  waitForComponents();
+  startApp();
 }

--- a/src/pages/sessions-page.js
+++ b/src/pages/sessions-page.js
@@ -1,4 +1,4 @@
-import { waitForFirebase } from '../shared-init.js';
+import { waitForFirebase, waitForComponents } from '../shared-init.js';
 import { listJulesSessions, getDecryptedJulesKey } from '../modules/jules-api.js';
 import { attachPromptViewerHandlers } from '../modules/prompt-viewer.js';
 
@@ -9,12 +9,9 @@ let cachedSessions = null;
 let cachedSearchData = null;
 let cachedFuseInstance = null;
 
-function waitForComponents() {
-  if (document.querySelector('header')) {
-    initApp();
-  } else {
-    setTimeout(waitForComponents, 50);
-  }
+async function startApp() {
+  await waitForComponents();
+  initApp();
 }
 
 async function loadSessionsPage() {
@@ -213,7 +210,7 @@ async function initApp() {
 }
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', waitForComponents);
+  document.addEventListener('DOMContentLoaded', startApp);
 } else {
-  waitForComponents();
+  startApp();
 }

--- a/src/pages/webcapture-page.js
+++ b/src/pages/webcapture-page.js
@@ -3,12 +3,11 @@
  * Handles extension download functionality
  */
 
-function waitForComponents() {
-  if (document.querySelector('header')) {
-    initApp();
-  } else {
-    setTimeout(waitForComponents, 50);
-  }
+import { waitForComponents } from '../shared-init.js';
+
+async function startApp() {
+  await waitForComponents();
+  initApp();
 }
 
 function initApp() {
@@ -48,7 +47,7 @@ function initApp() {
 }
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', waitForComponents);
+  document.addEventListener('DOMContentLoaded', startApp);
 } else {
-  waitForComponents();
+  startApp();
 }

--- a/src/shared-init.js
+++ b/src/shared-init.js
@@ -174,6 +174,19 @@ async function initializeSharedComponents(activePage) {
   }
 }
 
+function waitForComponents(selector = 'header') {
+  return new Promise((resolve) => {
+    function check() {
+      if (document.querySelector(selector)) {
+        resolve();
+      } else {
+        setTimeout(check, 50);
+      }
+    }
+    check();
+  });
+}
+
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => {
     const activePage = document.body.getAttribute('data-page') || 'home';
@@ -184,4 +197,4 @@ if (document.readyState === 'loading') {
   initializeSharedComponents(activePage);
 }
 
-export { initializeSharedComponents, waitForFirebase };
+export { initializeSharedComponents, waitForFirebase, waitForComponents };


### PR DESCRIPTION
Refactored the duplicate `waitForComponents` logic across multiple page modules into a single, shared utility in `src/shared-init.js`.

- Added `waitForComponents(selector)` to `src/shared-init.js` which returns a Promise.
- Updated `index-page.js`, `jules-page.js`, `profile-page.js`, `queue-page.js`, `sessions-page.js`, and `webcapture-page.js` to use the shared utility.
- Standardized initialization flow using async/await pattern.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/3cadb8d9-a764-440f-9c30-70eef535450c" />

---
https://jules.google.com/session/2557911938900817977