### PR TITLE
Refactor Firebase init to use event-driven loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-functions-compat.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/fuse.js/dist/fuse.min.js"></script>
-  <script src="src/firebase-init.js"></script>
+  <script type="module" src="src/firebase-init.js"></script>
 </head>
 <body data-page="home">
 

--- a/pages/jules/jules.html
+++ b/pages/jules/jules.html
@@ -15,7 +15,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-functions-compat.js"></script>
-  <script src="../../src/firebase-init.js"></script>
+  <script type="module" src="../../src/firebase-init.js"></script>
 </head>
 <body data-page="jules">
 

--- a/pages/privacy/privacy.html
+++ b/pages/privacy/privacy.html
@@ -9,7 +9,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>
-  <script src="../../src/firebase-init.js"></script>
+  <script type="module" src="../../src/firebase-init.js"></script>
 </head>
 <body data-page="privacy">
   <div class="wrap">

--- a/pages/profile/profile.html
+++ b/pages/profile/profile.html
@@ -15,7 +15,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-functions-compat.js"></script>
-  <script src="../../src/firebase-init.js"></script>
+  <script type="module" src="../../src/firebase-init.js"></script>
 </head>
 <body data-page="profile">
 

--- a/pages/queue/queue.html
+++ b/pages/queue/queue.html
@@ -15,7 +15,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-functions-compat.js"></script>
-  <script src="../../src/firebase-init.js"></script>
+  <script type="module" src="../../src/firebase-init.js"></script>
 </head>
 <body data-page="queue">
 

--- a/pages/sessions/sessions.html
+++ b/pages/sessions/sessions.html
@@ -16,7 +16,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-functions-compat.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/fuse.js/dist/fuse.min.js"></script>
-  <script src="../../src/firebase-init.js"></script>
+  <script type="module" src="../../src/firebase-init.js"></script>
 </head>
 <body data-page="sessions">
 

--- a/pages/webcapture/webcapture.html
+++ b/pages/webcapture/webcapture.html
@@ -15,7 +15,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-functions-compat.js"></script>
-  <script src="../../src/firebase-init.js"></script>
+  <script type="module" src="../../src/firebase-init.js"></script>
 </head>
 <body data-page="webcapture">
 

--- a/privacy.html
+++ b/privacy.html
@@ -11,7 +11,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-functions-compat.js"></script>
-  <script src="/src/firebase-init.js"></script>
+  <script type="module" src="/src/firebase-init.js"></script>
 </head>
 <body data-page="privacy">
   <div class="wrap">

--- a/src/firebase-init.js
+++ b/src/firebase-init.js
@@ -15,70 +15,120 @@ const firebaseConfig = {
   appId: "1:494845853842:web:6c97aec4822be003fc264b"
 };
 
-// Initialize Firebase when modular SDK is available
-function initFirebaseWhenReady() {
+function initFirebase() {
   try {
-    // Using the global firebase namespace that should be available after SDK loads
-    if (typeof firebase !== 'undefined' && firebase.initializeApp) {
-      // Initialize app
-      const app = firebase.initializeApp(firebaseConfig);
-      
-      // Get services - compat API doesn't require app parameter
-      window.auth = firebase.auth();
-      window.db = firebase.firestore();
-      window.functions = firebase.functions();
-      
-      // Port 5000 = dev server with emulators, port 3000 = production
-      const isDevServer = window.location.port === '5000';
-      
-      if (isDevServer && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')) {
-        try {
-          // Use the same hostname as the page to avoid CORS issues
-          const emulatorHost = window.location.hostname;
-          window.db.useEmulator(emulatorHost, 8080);
-          window.functions.useEmulator(emulatorHost, 5001);
-          console.log('🔧 Connected to Firebase Emulators (Firestore, Functions)');
-          console.log('⚠️ Dev server - using test data only');
-        } catch (emulatorError) {
-          console.error('Failed to connect to Firebase emulators:', emulatorError);
-          console.error('Make sure emulators are running: firebase emulators:start or docker-compose up');
-          console.log('🌐 Falling back to production Firebase backend');
-        }
-      } else {
-        console.log('🌐 Using production Firebase backend');
+    // Initialize app
+    const app = firebase.initializeApp(firebaseConfig);
+
+    // Get services - compat API doesn't require app parameter
+    window.auth = firebase.auth();
+    window.db = firebase.firestore();
+    window.functions = firebase.functions();
+
+    // Port 5000 = dev server with emulators, port 3000 = production
+    const isDevServer = window.location.port === '5000';
+
+    if (isDevServer && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')) {
+      try {
+        // Use the same hostname as the page to avoid CORS issues
+        const emulatorHost = window.location.hostname;
+        window.db.useEmulator(emulatorHost, 8080);
+        window.functions.useEmulator(emulatorHost, 5001);
+        console.log('🔧 Connected to Firebase Emulators (Firestore, Functions)');
+        console.log('⚠️ Dev server - using test data only');
+      } catch (emulatorError) {
+        console.error('Failed to connect to Firebase emulators:', emulatorError);
+        console.error('Make sure emulators are running: firebase emulators:start or docker-compose up');
+        console.log('🌐 Falling back to production Firebase backend');
       }
-      
-      window.firebaseReady = true;
-      
-      return true;
     } else {
-      return false;
+      console.log('🌐 Using production Firebase backend');
     }
+
+    window.firebaseReady = true;
+    return true;
   } catch (error) {
     console.error('Firebase initialization error:', error);
     window.firebaseError = error;
-    return false;
+    throw error;
   }
 }
 
-// Try to initialize immediately
-if (!initFirebaseWhenReady()) {
-  // If not ready, retry every 100ms for up to 30 seconds
-  let attempts = 0;
-  const maxAttempts = 300;
-  const retryInterval = setInterval(() => {
-    attempts++;
-    if (initFirebaseWhenReady() || attempts >= maxAttempts) {
-      clearInterval(retryInterval);
-      if (attempts >= maxAttempts) {
-        console.error('Failed to initialize Firebase after 30 seconds');
-        window.firebaseError = 'Timeout waiting for Firebase SDK';
+// Export a promise that resolves when Firebase is initialized
+export const firebaseReadyPromise = new Promise((resolve, reject) => {
+  // Check if all required Firebase components are loaded
+  const isReady = () => {
+    return typeof firebase !== 'undefined' &&
+           firebase.initializeApp &&
+           typeof firebase.auth === 'function' &&
+           typeof firebase.firestore === 'function' &&
+           typeof firebase.functions === 'function';
+  };
+
+  if (isReady()) {
+    try {
+      initFirebase();
+      resolve();
+    } catch (error) {
+      reject(error);
+    }
+    return;
+  }
+
+  // If not ready, listen for script load events
+  const scripts = document.querySelectorAll('script[src*="firebase-"]');
+  if (scripts.length === 0) {
+    reject(new Error('No Firebase scripts found in document'));
+    return;
+  }
+
+  let resolved = false;
+  const checkAndInit = () => {
+    if (resolved) return;
+
+    if (isReady()) {
+      try {
+        initFirebase();
+        resolved = true;
+        resolve();
+      } catch (error) {
+        resolved = true;
+        reject(error);
       }
     }
-  }, 100);
-}
+  };
 
-// Also expose a manual check function
+  scripts.forEach(script => {
+    script.addEventListener('load', checkAndInit);
+    script.addEventListener('error', (e) => {
+      if (!resolved) {
+        console.error('Error loading Firebase script:', script.src);
+      }
+    });
+  });
+
+  // Safety timeout
+  setTimeout(() => {
+    if (!resolved) {
+      resolved = true;
+      if (isReady()) {
+        // It might have become ready without triggering our specific listeners?
+        try {
+          initFirebase();
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      } else {
+        const error = new Error('Timeout waiting for Firebase SDK');
+        window.firebaseError = error.message;
+        reject(error);
+      }
+    }
+  }, 30000);
+});
+
+// Also expose a manual check function for backward compatibility
 window.checkFirebaseReady = function() {
   return window.firebaseReady;
 };

--- a/src/shared-init.js
+++ b/src/shared-init.js
@@ -7,18 +7,18 @@ import { initBranchSelector, loadBranches, loadBranchFromStorage } from './modul
 import { OWNER, REPO, BRANCH } from './utils/constants.js';
 import { parseParams } from './utils/url-params.js';
 import statusBar from './modules/status-bar.js';
+import { firebaseReadyPromise } from './firebase-init.js';
 
 let isInitialized = false;
 
-function waitForFirebase(callback, attempts = 0, maxAttempts = 100) {
-  if (window.firebaseReady) {
-    callback();
-  } else if (attempts < maxAttempts) {
-    setTimeout(() => waitForFirebase(callback, attempts + 1, maxAttempts), 100);
-  } else {
-    console.error('Firebase failed to initialize after', maxAttempts, 'attempts');
-    callback();
-  }
+function waitForFirebase(callback) {
+  firebaseReadyPromise
+    .then(() => callback())
+    .catch((error) => {
+      console.error('Firebase failed to initialize:', error);
+      // Still execute callback to allow app to function partially
+      callback();
+    });
 }
 
 function showUpdateBanner(latestDate, latestSha) {


### PR DESCRIPTION
Replaces the polling loop in `firebase-init.js` with a Promise-based architecture that resolves when Firebase SDK scripts load (using `onload` events). Updates `shared-init.js` to await this promise. Converts `firebase-init.js` to an ES module and updates all referencing HTML files.

---
https://jules.google.com/session/15229597250750027787