### PR TITLE
Remove unnecessary empty else blocks from shared-init.js

### DIFF
--- a/src/shared-init.js
+++ b/src/shared-init.js
@@ -90,7 +90,6 @@ async function fetchVersion() {
         currentDate = new Date(metaDate);
         currentDateStr = new Date(metaDate).toLocaleDateString('en-CA');
       }
-    } else {
     }
 
     if (currentDate < latestDate) {
@@ -114,7 +113,6 @@ async function fetchVersion() {
     }
     if (currentDate < latestDate) {
       showUpdateBanner(latestDateStr, latestSha);
-    } else {
     }
     
   } catch (error) {


### PR DESCRIPTION
I removed two empty `else` blocks found in `src/shared-init.js` that were remnants of conditional logic where no alternative action was required. This cleanup simplifies the code and removes dead logic.

Changes:
- Removed empty `else` block in `fetchVersion` function.
- Removed empty `else` block in `fetchVersion` function (second instance).

---
https://jules.google.com/session/15888596277663211230