### PR TITLE
Refactor clipboard usage to a centralized utility

### DIFF
--- a/src/modules/jules-free-input.js
+++ b/src/modules/jules-free-input.js
@@ -4,6 +4,7 @@ import { showJulesKeyModal, showSubtaskErrorModal } from './jules-modal.js';
 import { addToJulesQueue, handleQueueAction } from './jules-queue.js';
 import { RepoSelector, BranchSelector } from './repo-branch-selector.js';
 import { showToast } from './toast.js';
+import { copyText } from '../utils/clipboard.js';
 import { JULES_MESSAGES, TIMEOUTS, RETRY_CONFIG } from '../utils/constants.js';
 
 let _lastSelectedSourceId = null;
@@ -244,8 +245,8 @@ export function showFreeInputForm() {
       return;
     }
 
-    try {
-      await navigator.clipboard.writeText(promptText);
+    const success = await copyText(promptText);
+    if (success) {
       copenBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">check_circle</span> Copied!';
       setTimeout(() => {
         copenBtn.innerHTML = originalCopenLabel;
@@ -274,8 +275,8 @@ export function showFreeInputForm() {
           break;
       }
       window.open(url, '_blank', 'noopener,noreferrer');
-    } catch (error) {
-      showToast('Failed to copy prompt: ' + error.message, 'error');
+    } else {
+      showToast('Failed to copy prompt.', 'error');
     }
   };
 

--- a/src/modules/prompt-viewer.js
+++ b/src/modules/prompt-viewer.js
@@ -4,6 +4,7 @@
  */
 
 import { createElement } from '../utils/dom-helpers.js';
+import { copyText } from '../utils/clipboard.js';
 import { showToast } from './toast.js';
 import { TIMEOUTS } from '../utils/constants.js';
 
@@ -74,8 +75,8 @@ export function showPromptViewer(prompt, sessionId) {
   
   // Copy functionality
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(prompt);
+    const success = await copyText(prompt);
+    if (success) {
       const originalText = copyBtn.innerHTML;
       copyBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">check</span> Copied!';
       copyBtn.disabled = true;
@@ -84,8 +85,7 @@ export function showPromptViewer(prompt, sessionId) {
         copyBtn.innerHTML = originalText;
         copyBtn.disabled = false;
       }, TIMEOUTS.actionFeedback);
-    } catch (err) {
-      console.error('Copy failed:', err);
+    } else {
       showToast('Failed to copy prompt to clipboard', 'error');
     }
   };

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,0 +1,22 @@
+/**
+ * Clipboard utilities
+ */
+
+/**
+ * Copies text to the clipboard safely.
+ * @param {string} text - The text to copy.
+ * @returns {Promise<boolean>} - True if successful, false otherwise.
+ */
+export async function copyText(text) {
+  if (!navigator.clipboard) {
+    console.warn('Clipboard API not available');
+    return false;
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch (error) {
+    console.error('Failed to copy text:', error);
+    return false;
+  }
+}


### PR DESCRIPTION
Created src/utils/clipboard.js with a robust copyText function and updated prompt-renderer.js, jules-free-input.js, and prompt-viewer.js to use it, replacing direct navigator.clipboard calls.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/1a9418dd-faa9-4358-8e07-0043a8ead2fd" />

---
https://jules.google.com/session/14117208264515823125