### PR TITLE
Refactor version badge inline styles to CSS classes

### DIFF
--- a/src/shared-init.js
+++ b/src/shared-init.js
@@ -48,6 +48,7 @@ function showUpdateBanner(latestDate, latestSha) {
   dismissButton.addEventListener('click', () => {
     localStorage.setItem(`dismissed-version-${latestSha}`, 'true');
     banner.remove();
+    document.body.classList.remove('has-version-banner');
   });
 
   buttonContainer.appendChild(refreshButton);
@@ -58,7 +59,7 @@ function showUpdateBanner(latestDate, latestSha) {
 
   document.body.insertBefore(banner, document.body.firstChild);
 
-  document.body.style.paddingTop = '48px';
+  document.body.classList.add('has-version-banner');
 }
 
 async function fetchVersion() {
@@ -94,17 +95,11 @@ async function fetchVersion() {
 
     if (currentDate < latestDate) {
       appVersion.textContent = `v${currentDateStr} (${currentSha})`;
-      appVersion.style.background = '';
-      appVersion.style.borderRadius = '';
-      appVersion.style.padding = '';
-      appVersion.style.fontWeight = 'bold';
-      appVersion.style.color = '#ffe066'; // yellow text
+      appVersion.classList.add('version-badge', 'version-badge--new');
     } else {
       appVersion.textContent = `v${latestDateStr} (${latestSha})`;
-      appVersion.style.background = '';
-      appVersion.style.color = '';
-      appVersion.style.borderRadius = '';
-      appVersion.style.padding = '';
+      appVersion.classList.add('version-badge');
+      appVersion.classList.remove('version-badge--new');
     }
     
     const dismissed = localStorage.getItem(`dismissed-version-${latestSha}`);

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -185,6 +185,15 @@ button.mobile-nav-item { border: none; background: transparent; cursor: pointer;
 #authStatus { display:flex; align-items:center; gap:6px; font-size:13px; flex-shrink:0; }
 #appVersion { color: var(--muted); font-size: 10px; opacity: 0.7; margin-top: 4px; font-family: monospace; }
 
+.version-badge {
+  /* Base class for version badge */
+}
+
+#appVersion.version-badge--new {
+  font-weight: bold;
+  color: #ffe066;
+}
+
 .site-title { font-size:16px; font-weight:900; letter-spacing:0.4px; line-height:1.2; }
 .site-tagline { color:var(--muted); font-size:10px; margin-top:2px; }
 #dropdownAvatar { width:32px; height:32px; border-radius:50%; }

--- a/src/styles/components/update-banner.css
+++ b/src/styles/components/update-banner.css
@@ -48,6 +48,11 @@
   margin-left: 8px;
 }
 
+/* Body adjustment when banner is present */
+body.has-version-banner {
+  padding-top: 48px;
+}
+
 /* Responsive behavior */
 @media (max-width: 600px) {
   .update-banner {


### PR DESCRIPTION
Refactored `src/shared-init.js` to use CSS classes (`.version-badge`, `.version-badge--new`) and `body.has-version-banner` instead of inline styles.
Added corresponding styles in `src/styles/components/header.css` and `src/styles/components/update-banner.css`.
Verified behavior with Playwright tests (banner appearance, badge styling, dismissal).

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/19015f85-252d-4acd-9372-4b301135e84c" />

---
https://jules.google.com/session/2614614151008795506