### PR TITLE
feat: shared Jules status renderer

### DIFF
--- a/src/modules/jules-modal.js
+++ b/src/modules/jules-modal.js
@@ -50,7 +50,7 @@ export function showJulesKeyModal(onSave) {
   const modal = document.getElementById('julesKeyModal');
   const input = document.getElementById('julesKeyInput');
   
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.add('show');
   input.value = '';
   input.focus();
 
@@ -101,12 +101,12 @@ export function showJulesKeyModal(onSave) {
 
 export function hideJulesKeyModal() {
   const modal = document.getElementById('julesKeyModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.remove('show');
 }
 
 export async function showJulesEnvModal(promptText) {
   const modal = document.getElementById('julesEnvModal');
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.add('show');
 
   const submitBtn = document.getElementById('julesEnvSubmitBtn');
   const queueBtn = document.getElementById('julesEnvQueueBtn');
@@ -299,7 +299,7 @@ async function handleRepoSelect(sourceId, branch, promptText, suppressPopups = f
 
 export function hideJulesEnvModal() {
   const modal = document.getElementById('julesEnvModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.remove('show');
 }
 
 export async function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error, hideQueueButton = false) {
@@ -393,10 +393,10 @@ export function initJulesKeyModalListeners() {
 
   document.addEventListener('keydown', async (e) => {
     if (e.key === 'Escape') {
-      if (keyModal && keyModal.style.display === 'flex') {
+      if (keyModal && keyModal.classList.contains('show')) {
         hideJulesKeyModal();
       }
-      if (envModal && envModal.style.display === 'flex') {
+      if (envModal && envModal.classList.contains('show')) {
         hideJulesEnvModal();
       }
       const freeInputSection = document.getElementById('freeInputSection');
@@ -404,11 +404,11 @@ export function initJulesKeyModalListeners() {
         const { hideFreeInputForm } = await import('./jules-free-input.js?v=' + Date.now());
         hideFreeInputForm();
       }
-      if (profileModal && profileModal.style.display === 'flex') {
+      if (profileModal && profileModal.classList.contains('show')) {
         const { hideUserProfileModal } = await import('./jules-account.js');
         hideUserProfileModal();
       }
-      if (sessionsHistoryModal && sessionsHistoryModal.style.display === 'flex') {
+      if (sessionsHistoryModal && sessionsHistoryModal.classList.contains('show')) {
         const { hideJulesSessionsHistoryModal } = await import('./jules-account.js');
         hideJulesSessionsHistoryModal();
       }

--- a/src/modules/status-renderer.js
+++ b/src/modules/status-renderer.js
@@ -1,0 +1,57 @@
+/**
+ * Shared Jules Status Renderer
+ * Standardizes status element creation and updates.
+ */
+
+import { createIcon, clearElement } from '../utils/dom-helpers.js';
+
+export const STATUS_TYPES = {
+  SAVED: 'saved',
+  NOT_SAVED: 'not-saved',
+  LOADING: 'loading',
+  ERROR: 'error',
+  SUCCESS: 'success',
+  DELETING: 'deleting',
+  RESET: 'reset'
+};
+
+const STATUS_CONFIG = {
+  [STATUS_TYPES.SAVED]: { icon: 'check_circle', colorClass: 'color-accent' },
+  [STATUS_TYPES.NOT_SAVED]: { icon: 'cancel', colorClass: 'color-muted' },
+  [STATUS_TYPES.LOADING]: { icon: 'hourglass_top', colorClass: '' },
+  [STATUS_TYPES.ERROR]: { icon: 'error', colorClass: 'color-error' },
+  [STATUS_TYPES.SUCCESS]: { icon: 'check_circle', colorClass: 'color-success' },
+  [STATUS_TYPES.DELETING]: { icon: 'hourglass_top', colorClass: '' },
+  [STATUS_TYPES.RESET]: { icon: 'refresh', colorClass: '' }
+};
+
+/**
+ * Renders a status icon and label into a container.
+ * @param {HTMLElement} container The container element.
+ * @param {string} type The status type (from STATUS_TYPES).
+ * @param {string} [labelOverride] Optional label text to override default or display custom text.
+ */
+export function renderStatus(container, type, labelOverride = null) {
+  if (!container) return;
+
+  clearElement(container);
+
+  const config = STATUS_CONFIG[type] || { icon: 'info', colorClass: '' };
+
+  // Remove existing color classes
+  container.classList.remove('color-accent', 'color-muted', 'color-error', 'color-success');
+
+  // Apply new color class if specified
+  if (config.colorClass) {
+    container.classList.add(config.colorClass);
+  }
+
+  // Create icon
+  const icon = createIcon(config.icon, ['icon-inline']);
+  container.appendChild(icon);
+
+  // Add text
+  if (labelOverride) {
+    container.appendChild(document.createTextNode(' ' + labelOverride));
+  }
+}

--- a/src/pages/jules-page.js
+++ b/src/pages/jules-page.js
@@ -10,6 +10,7 @@ import { deleteStoredJulesKey, checkJulesKey } from '../modules/jules-keys.js';
 import { showToast } from '../modules/toast.js';
 import { showConfirm } from '../modules/confirm-modal.js';
 import { TIMEOUTS } from '../utils/constants.js';
+import { renderStatus, STATUS_TYPES } from '../modules/status-renderer.js';
 
 function waitForComponents() {
   if (document.querySelector('header')) {
@@ -46,10 +47,11 @@ async function loadJulesInfo() {
     const hasKey = await checkJulesKey(user.uid);
     
     if (julesKeyStatus) {
-      julesKeyStatus.innerHTML = hasKey 
-        ? '<span class="icon icon-inline" aria-hidden="true">check_circle</span> Saved'
-        : '<span class="icon icon-inline" aria-hidden="true">cancel</span> Not saved';
-      julesKeyStatus.style.color = hasKey ? 'var(--accent)' : 'var(--muted)';
+      renderStatus(
+        julesKeyStatus,
+        hasKey ? STATUS_TYPES.SAVED : STATUS_TYPES.NOT_SAVED,
+        hasKey ? 'Saved' : 'Not saved'
+      );
     }
     
     loadingDiv.classList.add('hidden');
@@ -61,7 +63,7 @@ async function loadJulesInfo() {
       if (noJulesKeySection) noJulesKeySection.classList.add('hidden');
       if (julesContentSection) julesContentSection.classList.remove('hidden');
       if (dangerZoneSection) dangerZoneSection.classList.remove('hidden');
-      if (loadJulesInfoBtn) loadJulesInfoBtn.style.display = 'block';
+      if (loadJulesInfoBtn) loadJulesInfoBtn.classList.remove('hidden');
       
       // Load Jules account information
       await loadJulesAccountInfo(user);
@@ -69,7 +71,7 @@ async function loadJulesInfo() {
       if (noJulesKeySection) noJulesKeySection.classList.remove('hidden');
       if (julesContentSection) julesContentSection.classList.add('hidden');
       if (dangerZoneSection) dangerZoneSection.classList.add('hidden');
-      if (loadJulesInfoBtn) loadJulesInfoBtn.style.display = 'none';
+      if (loadJulesInfoBtn) loadJulesInfoBtn.classList.add('hidden');
     }
   } catch (err) {
     console.error('Jules info loading error:', err);
@@ -116,11 +118,18 @@ function initApp() {
         if (deleted) {
           const julesKeyStatus = document.getElementById('julesKeyStatus');
           if (julesKeyStatus) {
-            julesKeyStatus.innerHTML = '<span class="icon icon-inline" aria-hidden="true">cancel</span> Not saved';
-            julesKeyStatus.style.color = 'var(--muted)';
+            renderStatus(julesKeyStatus, STATUS_TYPES.NOT_SAVED, 'Not saved');
           }
           
-          resetJulesKeyBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">delete</span> Delete Jules API Key';
+          // Restore button
+          resetJulesKeyBtn.innerHTML = '';
+          const icon = document.createElement('span');
+          icon.className = 'icon icon-inline';
+          icon.setAttribute('aria-hidden', 'true');
+          icon.textContent = 'delete';
+          resetJulesKeyBtn.appendChild(icon);
+          resetJulesKeyBtn.appendChild(document.createTextNode(' Delete Jules API Key'));
+
           resetJulesKeyBtn.disabled = false;
           
           const noJulesKeySection = document.getElementById('noJulesKeySection');
@@ -136,7 +145,7 @@ function initApp() {
         }
       } catch (error) {
         showToast('Failed to delete API key: ' + error.message, 'error');
-        resetJulesKeyBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">delete</span> Delete Jules API Key';
+        renderStatus(resetJulesKeyBtn, STATUS_TYPES.RESET, 'Delete Jules API Key');
         resetJulesKeyBtn.disabled = false;
       }
     };

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,6 +11,7 @@
 @import url('./styles/components/pills.css');
 @import url('./styles/components/dropdown.css');
 @import url('./styles/components/modals.css');
+@import url('./styles/components/jules-modals.css');
 @import url('./styles/components/card.css');
 @import url('./styles/components/list.css');
 @import url('./styles/components/tree.css');

--- a/src/styles/components/jules-modals.css
+++ b/src/styles/components/jules-modals.css
@@ -1,0 +1,38 @@
+
+/* Jules Modals */
+#julesEnvModal,
+#subtaskErrorModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 1000;
+  display: none !important;
+  align-items: center;
+  justify-content: center;
+}
+
+#julesEnvModal.show,
+#subtaskErrorModal.show {
+  display: flex !important;
+}
+
+/* Modal Content Containers */
+#julesEnvModal > div,
+#subtaskErrorModal > div {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 24px;
+  max-width: 600px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+#subtaskErrorModal > div {
+  max-width: 500px;
+}

--- a/src/utils/dom-helpers.js
+++ b/src/utils/dom-helpers.js
@@ -7,6 +7,19 @@ export function createElement(tag, className = '', textContent = '') {
   return el;
 }
 
+export function createIcon(iconName, classes = [], ariaHidden = true) {
+  const span = document.createElement('span');
+  span.className = 'icon';
+  if (Array.isArray(classes)) {
+    classes.forEach(c => span.classList.add(c));
+  } else if (typeof classes === 'string' && classes) {
+    span.classList.add(classes);
+  }
+  span.textContent = iconName;
+  if (ariaHidden) span.setAttribute('aria-hidden', 'true');
+  return span;
+}
+
 /**
  * Toggles the visibility of an element by adding or removing the '.hidden' class.
  * Note: This relies on a global '.hidden' class with 'display: none !important;'.


### PR DESCRIPTION
- Added `createIcon` utility to `src/utils/dom-helpers.js`
- Created `src/modules/status-renderer.js` to standardize status UI
- Updated `src/modules/jules-account.js` and `src/pages/jules-page.js` to use status renderer
- Replaced inline style visibility toggling with `.hidden`/`.show` classes
- Added `src/styles/components/jules-modals.css` to support modal class-based toggling

---
https://jules.google.com/session/3227332020358634267