### PR TITLE
Refactor confirm-modal to use DOM API calls

### DIFF
--- a/src/modules/confirm-modal.js
+++ b/src/modules/confirm-modal.js
@@ -1,35 +1,58 @@
 // ===== Confirmation Modal Module =====
 // Provides styled confirmation dialogs to replace confirm() calls
 
+import { TIMEOUTS } from '../utils/constants.js';
+import { createElement } from '../utils/dom-helpers.js';
+
 let confirmModal = null;
 let confirmResolve = null;
 
 function createConfirmModal() {
-  const modal = document.createElement('div');
+  const modal = createElement('div', 'modal');
   modal.id = 'confirmModal';
-  modal.className = 'modal';
   modal.style.zIndex = '10000';
-  modal.innerHTML = `
-    <div class="modal-content" style="max-width: 480px;">
-      <div class="modal-header">
-        <h3 id="confirmModalTitle">Confirm Action</h3>
-        <button class="btn-icon close-modal" id="confirmModalClose" title="Close">✕</button>
-      </div>
-      <div class="modal-body">
-        <p id="confirmModalMessage" style="line-height: 1.6; white-space: pre-wrap;"></p>
-      </div>
-      <div class="modal-buttons">
-        <button id="confirmModalCancel" class="btn">Cancel</button>
-        <button id="confirmModalConfirm" class="btn danger">Confirm</button>
-      </div>
-    </div>
-  `;
+
+  const modalContent = createElement('div', 'modal-content');
+  modalContent.style.maxWidth = '480px';
+
+  const modalHeader = createElement('div', 'modal-header');
+  const title = createElement('h3', '', 'Confirm Action');
+  title.id = 'confirmModalTitle';
+
+  const closeBtn = createElement('button', 'btn-icon close-modal', '✕');
+  closeBtn.id = 'confirmModalClose';
+  closeBtn.title = 'Close';
+
+  modalHeader.appendChild(title);
+  modalHeader.appendChild(closeBtn);
+
+  const modalBody = createElement('div', 'modal-body');
+  const message = createElement('p');
+  message.id = 'confirmModalMessage';
+  message.style.lineHeight = '1.6';
+  message.style.whiteSpace = 'pre-wrap';
+
+  modalBody.appendChild(message);
+
+  const modalButtons = createElement('div', 'modal-buttons');
+  const cancelBtn = createElement('button', 'btn', 'Cancel');
+  cancelBtn.id = 'confirmModalCancel';
+
+  const confirmBtn = createElement('button', 'btn danger', 'Confirm');
+  confirmBtn.id = 'confirmModalConfirm';
+
+  modalButtons.appendChild(cancelBtn);
+  modalButtons.appendChild(confirmBtn);
+
+  modalContent.appendChild(modalHeader);
+  modalContent.appendChild(modalBody);
+  modalContent.appendChild(modalButtons);
+
+  modal.appendChild(modalContent);
   
   document.body.appendChild(modal);
   return modal;
 }
-
-import { TIMEOUTS } from '../utils/constants.js';
 
 function showConfirmModal() {
   if (!confirmModal) {


### PR DESCRIPTION
Replaces innerHTML usage in confirm-modal.js with createElement calls to improve security and prevent XSS. Verification:
- Added temporary test page and Playwright script to verify modal appearance and functionality.
- Confirmed modal structure and styles are preserved.
- Verified visibility and layout.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/9f067015-0acb-4f8a-9c9b-4b457fc6b3e2" />

---
https://jules.google.com/session/12313322707607019649