### PR TITLE
Refactor modal system to use CSS classes instead of inline styles

### DIFF
--- a/src/modules/confirm-modal.js
+++ b/src/modules/confirm-modal.js
@@ -7,8 +7,7 @@ let confirmResolve = null;
 function createConfirmModal() {
   const modal = document.createElement('div');
   modal.id = 'confirmModal';
-  modal.className = 'modal';
-  modal.style.zIndex = '10000';
+  modal.className = 'modal modal-high-z';
   modal.innerHTML = `
     <div class="modal-content" style="max-width: 480px;">
       <div class="modal-header">

--- a/src/modules/jules-account.js
+++ b/src/modules/jules-account.js
@@ -89,9 +89,9 @@ export function showUserProfileModal() {
           resetBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">delete</span> Delete Jules API Key';
           resetBtn.disabled = false;
           
-          if (addBtn) addBtn.style.display = 'block';
-          if (dangerZoneSection) dangerZoneSection.style.display = 'none';
-          if (julesProfileInfoSection) julesProfileInfoSection.style.display = 'none';
+          if (addBtn) addBtn.classList.remove('d-none');
+          if (dangerZoneSection) dangerZoneSection.classList.add('d-none');
+          if (julesProfileInfoSection) julesProfileInfoSection.classList.add('d-none');
           
           showToast('Jules API key has been deleted. You can enter a new one next time.', 'success');
         } else {
@@ -317,7 +317,7 @@ export function showJulesSessionsHistoryModal() {
   const modal = document.getElementById('julesSessionsHistoryModal');
   const searchInput = document.getElementById('sessionSearchInput');
   
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1002; flex-direction:column; align-items:center; justify-content:center; overflow-y:auto; padding:20px;');
+  modal.classList.add('show');
   
   allSessionsCache = [];
   sessionNextPageToken = null;
@@ -328,7 +328,7 @@ export function showJulesSessionsHistoryModal() {
 
 export function hideJulesSessionsHistoryModal() {
   const modal = document.getElementById('julesSessionsHistoryModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1002; flex-direction:column; align-items:center; justify-content:center; overflow-y:auto; padding:20px;');
+  modal.classList.remove('show');
 }
 
 async function loadSessionsPage() {
@@ -478,15 +478,15 @@ export async function loadProfileDirectly(user) {
   }
   
   if (hasKey) {
-    if (addBtn) addBtn.style.display = 'none';
-    if (dangerZoneSection) dangerZoneSection.style.display = 'block';
-    if (julesProfileInfoSection) julesProfileInfoSection.style.display = 'block';
+    if (addBtn) addBtn.classList.add('d-none');
+    if (dangerZoneSection) dangerZoneSection.classList.remove('d-none');
+    if (julesProfileInfoSection) julesProfileInfoSection.classList.remove('d-none');
     
     await loadAndDisplayJulesProfile(user.uid);
   } else {
-    if (addBtn) addBtn.style.display = 'block';
-    if (dangerZoneSection) dangerZoneSection.style.display = 'none';
-    if (julesProfileInfoSection) julesProfileInfoSection.style.display = 'none';
+    if (addBtn) addBtn.classList.remove('d-none');
+    if (dangerZoneSection) dangerZoneSection.classList.add('d-none');
+    if (julesProfileInfoSection) julesProfileInfoSection.classList.add('d-none');
   }
 
   // Attach event handlers
@@ -520,9 +520,9 @@ export async function loadProfileDirectly(user) {
           resetBtn.innerHTML = originalResetLabel;
           resetBtn.disabled = false;
           
-          if (addBtn) addBtn.style.display = 'block';
-          if (dangerZoneSection) dangerZoneSection.style.display = 'none';
-          if (julesProfileInfoSection) julesProfileInfoSection.style.display = 'none';
+          if (addBtn) addBtn.classList.remove('d-none');
+          if (dangerZoneSection) dangerZoneSection.classList.add('d-none');
+          if (julesProfileInfoSection) julesProfileInfoSection.classList.add('d-none');
           
           showToast('Jules API key has been deleted. You can enter a new one next time.', 'success');
         } else {
@@ -560,13 +560,13 @@ export async function loadJulesAccountInfo(user) {
   
   if (!hasKey) {
     if (julesProfileInfoSection) {
-      julesProfileInfoSection.style.display = 'none';
+      julesProfileInfoSection.classList.add('d-none');
     }
     return;
   }
 
   if (julesProfileInfoSection) {
-    julesProfileInfoSection.style.display = 'block';
+    julesProfileInfoSection.classList.remove('d-none');
   }
 
   await loadAndDisplayJulesProfile(user.uid);

--- a/src/modules/jules-modal.js
+++ b/src/modules/jules-modal.js
@@ -50,7 +50,7 @@ export function showJulesKeyModal(onSave) {
   const modal = document.getElementById('julesKeyModal');
   const input = document.getElementById('julesKeyInput');
   
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.add('modal-overlay-fixed', 'show');
   input.value = '';
   input.focus();
 
@@ -101,12 +101,12 @@ export function showJulesKeyModal(onSave) {
 
 export function hideJulesKeyModal() {
   const modal = document.getElementById('julesKeyModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.remove('modal-overlay-fixed', 'show');
 }
 
 export async function showJulesEnvModal(promptText) {
   const modal = document.getElementById('julesEnvModal');
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.add('modal-overlay-fixed', 'show');
 
   const submitBtn = document.getElementById('julesEnvSubmitBtn');
   const queueBtn = document.getElementById('julesEnvQueueBtn');
@@ -299,7 +299,7 @@ async function handleRepoSelect(sourceId, branch, promptText, suppressPopups = f
 
 export function hideJulesEnvModal() {
   const modal = document.getElementById('julesEnvModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.remove('modal-overlay-fixed', 'show');
 }
 
 export async function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error, hideQueueButton = false) {
@@ -324,9 +324,9 @@ export async function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error,
   }
 
   if (hideQueueButton && queueBtn) {
-    queueBtn.style.display = 'none';
+    queueBtn.classList.add('d-none');
   } else if (queueBtn) {
-    queueBtn.style.display = '';
+    queueBtn.classList.remove('d-none');
   }
 
   return new Promise((resolve) => {
@@ -334,8 +334,7 @@ export async function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error,
     messageDiv.textContent = error.message || String(error);
     detailsDiv.textContent = error.toString();
 
-    modal.style.zIndex = '10000';
-    modal.classList.add('show');
+    modal.classList.add('show', 'modal-high-z');
 
     const handleAction = (action) => {
       retryBtn.onclick = null;
@@ -379,7 +378,7 @@ export async function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error,
 export function hideSubtaskErrorModal() {
   const modal = document.getElementById('subtaskErrorModal');
   if (modal) {
-    modal.classList.remove('show');
+    modal.classList.remove('show', 'modal-high-z');
   }
 }
 
@@ -393,10 +392,10 @@ export function initJulesKeyModalListeners() {
 
   document.addEventListener('keydown', async (e) => {
     if (e.key === 'Escape') {
-      if (keyModal && keyModal.style.display === 'flex') {
+      if (keyModal && keyModal.classList.contains('modal-overlay-fixed')) {
         hideJulesKeyModal();
       }
-      if (envModal && envModal.style.display === 'flex') {
+      if (envModal && envModal.classList.contains('modal-overlay-fixed')) {
         hideJulesEnvModal();
       }
       const freeInputSection = document.getElementById('freeInputSection');
@@ -404,11 +403,11 @@ export function initJulesKeyModalListeners() {
         const { hideFreeInputForm } = await import('./jules-free-input.js?v=' + Date.now());
         hideFreeInputForm();
       }
-      if (profileModal && profileModal.style.display === 'flex') {
+      if (profileModal && profileModal.classList.contains('show')) {
         const { hideUserProfileModal } = await import('./jules-account.js');
         hideUserProfileModal();
       }
-      if (sessionsHistoryModal && sessionsHistoryModal.style.display === 'flex') {
+      if (sessionsHistoryModal && sessionsHistoryModal.classList.contains('show')) {
         const { hideJulesSessionsHistoryModal } = await import('./jules-account.js');
         hideJulesSessionsHistoryModal();
       }

--- a/src/modules/jules-queue.js
+++ b/src/modules/jules-queue.js
@@ -87,7 +87,7 @@ export function showJulesQueueModal() {
     console.error('julesQueueModal element not found!');
     return;
   }
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1003; flex-direction:column; align-items:center; justify-content:center; overflow-y:auto; padding:20px;');
+  modal.classList.add('show');
   
   modal.onclick = (e) => {
     if (e.target === modal) {
@@ -100,7 +100,7 @@ export function showJulesQueueModal() {
 
 export function hideJulesQueueModal() {
   const modal = document.getElementById('julesQueueModal');
-  if (modal) modal.setAttribute('style', 'display:none !important;');
+  if (modal) modal.classList.remove('show');
 }
 
 export function renderQueueListDirectly(items) {
@@ -358,7 +358,7 @@ async function openEditQueueModal(docId) {
 
   await initializeEditRepoAndBranch(item.sourceId, item.branch || 'master', repoDropdownBtn, repoDropdownText, repoDropdownMenu, branchDropdownBtn, branchDropdownText, branchDropdownMenu);
 
-  modal.style.display = 'flex';
+  modal.classList.add('show');
 
   const trackChanges = () => {
     editModalState.hasUnsavedChanges = true;
@@ -516,7 +516,7 @@ async function closeEditModal(force = false) {
     });
     if (!confirmed) return;
   }
-  modal.style.display = 'none';
+  modal.classList.remove('show');
   editModalState.hasUnsavedChanges = false;
   editModalState.originalData = null;
   editModalState.currentDocId = null;
@@ -739,7 +739,7 @@ async function showScheduleModal() {
   initializeScheduleModalInputs();
   attachScheduleModalHandlers();
   
-  modal.style.display = 'flex';
+  modal.classList.add('show');
 }
 
 async function loadScheduleModal() {
@@ -846,7 +846,7 @@ function attachScheduleModalHandlers() {
 function hideScheduleModal() {
   const modal = document.getElementById('scheduleQueueModal');
   if (modal) {
-    modal.style.display = 'none';
+    modal.classList.remove('show');
     const errorDiv = document.getElementById('scheduleError');
     if (errorDiv) {
       errorDiv.classList.add('hidden');

--- a/src/styles/components/modals.css
+++ b/src/styles/components/modals.css
@@ -1,6 +1,10 @@
 /* Modals & Jules Key Modal */
 #julesKeyModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1000; display: none !important; align-items: center; justify-content: center; }
 #julesKeyModal.show { display: flex !important; }
+
+#julesEnvModal { display: none; }
+#julesEnvModal.show { display: flex !important; }
+
 #julesKeyModal > div { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; max-width: 400px; width: 90%; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); }
 #julesKeyModal h2 { margin: 0 0 12px; font-size: 18px; }
 #julesKeyModal p { margin: 0 0 16px; color: var(--muted); font-size: 13px; }
@@ -11,6 +15,23 @@
 .modal { display: none !important; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1000; flex-direction: column; align-items: center; justify-content: center; }
 .modal.show { display: flex !important; }
 
+/* New class to replace inline styles */
+.modal-overlay-fixed {
+  position: fixed;
+  inset: 0; /* shorthand for top:0; right:0; bottom:0; left:0 */
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 1001;
+  display: flex !important; /* Force display flex when this class is added, similar to .show but explicit for the replacement */
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+/* High Z-Index for critical modals */
+.modal-high-z {
+  z-index: 10000 !important;
+}
+
 /* User Profile Modal specific */
 #userProfileModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1001; display: none; flex-direction: column; align-items: center; justify-content: center; overflow-y: auto; padding: 20px; }
 #userProfileModal.show { display: flex !important; }
@@ -19,8 +40,16 @@
 #allSessionsModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1002; display: none; flex-direction: column; align-items: center; justify-content: center; overflow-y: auto; padding: 20px; }
 #allSessionsModal.show { display: flex !important; }
 
+/* Jules Sessions History Modal (uses same styles as allSessionsModal) */
+#julesSessionsHistoryModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1002; display: none; flex-direction: column; align-items: center; justify-content: center; overflow-y: auto; padding: 20px; }
+#julesSessionsHistoryModal.show { display: flex !important; }
+
 /* Edit Queue Modal specific */
 #editQueueItemModal { z-index: 1003; }
+
+/* Jules Queue Modal specific */
+#julesQueueModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1003; display: none; flex-direction: column; align-items: center; justify-content: center; overflow-y: auto; padding: 20px; }
+#julesQueueModal.show { display: flex !important; }
 
 .modal-content { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; max-width: 400px; width: 90%; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); }
 .modal-content.modal-lg { max-width: 600px; max-height: 85vh; display: flex; flex-direction: column; overflow-y: auto; }
@@ -61,6 +90,8 @@
 
 /* Modal overlay and dialog structure */
 .modal-overlay { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1001; align-items: center; justify-content: center; padding: 20px; overflow-y: auto; }
+.modal-overlay.show { display: flex !important; }
+
 .modal-dialog { background: var(--card); border: 1px solid var(--border); border-radius: 14px; max-width: 600px; width: 100%; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); max-height: 90vh; display: flex; flex-direction: column; overflow: hidden; }
 .modal-dialog-sm { max-width: 500px; }
 .modal-dialog-lg { max-width: 700px; }


### PR DESCRIPTION
- Updated `src/styles/components/modals.css` with `.modal-overlay-fixed`, `.modal-high-z`, `#julesSessionsHistoryModal`, `#julesQueueModal`, and `#julesEnvModal`.
- Refactored `src/modules/jules-modal.js` to use `classList.add/remove` and remove inline `setAttribute('style', ...)`.
- Refactored `src/modules/confirm-modal.js` to use `.modal-high-z`.
- Refactored `src/modules/jules-account.js` to use `.show` and `.d-none` instead of inline styles.
- Refactored `src/modules/jules-queue.js` to use `.show` and `.d-none` instead of inline styles.
- Replaced `modal.style.display` checks with `modal.classList.contains()`.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/073b0d98-645b-4e38-b397-98aaae5c5460" />

---
https://jules.google.com/session/4928524340966750923