### PR TITLE
feat: implement unified dropdown manager

### DIFF
--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -1,13 +1,19 @@
 const openDropdowns = new Set();
+const registry = new Map();
 
+/**
+ * Closes all open dropdowns.
+ */
 function closeAllDropdowns() {
   for (const dropdown of openDropdowns) {
-    dropdown.menu.classList.remove('open');
-    dropdown.btn.setAttribute('aria-expanded', 'false');
+    closeDropdown(dropdown);
   }
-  openDropdowns.clear();
 }
 
+/**
+ * Toggles a dropdown's state.
+ * @param {Object} dropdown
+ */
 function toggleDropdown(dropdown) {
   const isOpen = dropdown.menu.classList.contains('open');
   if (isOpen) {
@@ -17,58 +23,192 @@ function toggleDropdown(dropdown) {
   }
 }
 
+/**
+ * Opens a dropdown.
+ * @param {Object} dropdown
+ */
 function openDropdown(dropdown) {
+  // Close others if we want single-open behavior (usually yes for menus)
   closeAllDropdowns();
+
   dropdown.menu.classList.add('open');
-  dropdown.menu.style.display = ''; // Clear inline style if present
-  dropdown.btn.setAttribute('aria-expanded', 'true');
+  dropdown.menu.classList.add('dropdown-open'); // For compatibility with user request
+  dropdown.menu.style.display = ''; // Ensure no inline display: none conflicts
+
+  if (dropdown.btn) {
+    dropdown.btn.setAttribute('aria-expanded', 'true');
+  }
+
   openDropdowns.add(dropdown);
+
+  if (dropdown.onOpen) dropdown.onOpen();
+
+  // Focus first item if requested (optional, maybe not default for mouse clicks)
+  // But for keyboard access, we handle focus management in keydown listener
 }
 
+/**
+ * Closes a specific dropdown.
+ * @param {Object} dropdown
+ */
 function closeDropdown(dropdown) {
   dropdown.menu.classList.remove('open');
-  dropdown.btn.setAttribute('aria-expanded', 'false');
+  dropdown.menu.classList.remove('dropdown-open');
+
+  if (dropdown.btn) {
+    dropdown.btn.setAttribute('aria-expanded', 'false');
+  }
+
   openDropdowns.delete(dropdown);
+
+  if (dropdown.onClose) dropdown.onClose();
 }
 
-// Centralized document click listener
+/**
+ * Handles keyboard navigation for dropdowns.
+ * @param {KeyboardEvent} e
+ * @param {Object} dropdown
+ */
+function handleDropdownKeydown(e, dropdown) {
+  const menu = dropdown.menu;
+  if (!menu.classList.contains('open')) return;
+
+  const items = Array.from(menu.querySelectorAll('a, button, .custom-dropdown-item, [role="menuitem"], [tabindex]:not([tabindex="-1"])'))
+    .filter(el => !el.disabled && el.offsetParent !== null); // Visible and enabled
+
+  if (items.length === 0) return;
+
+  const activeElement = document.activeElement;
+  const currentIndex = items.indexOf(activeElement);
+
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    const nextIndex = (currentIndex + 1) % items.length;
+    items[nextIndex].focus();
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    const prevIndex = (currentIndex - 1 + items.length) % items.length;
+    items[prevIndex].focus();
+  } else if (e.key === 'Home') {
+    e.preventDefault();
+    items[0].focus();
+  } else if (e.key === 'End') {
+    e.preventDefault();
+    items[items.length - 1].focus();
+  } else if (e.key === 'Enter' || e.key === ' ') {
+    // Let default action happen for links/buttons, but if it's a div with role menuitem, we might need to trigger click
+    if (activeElement !== dropdown.btn && items.includes(activeElement)) {
+        // If it's not a native interactive element, trigger click
+        if (activeElement.tagName !== 'A' && activeElement.tagName !== 'BUTTON' && activeElement.tagName !== 'INPUT') {
+             e.preventDefault();
+             activeElement.click();
+        }
+    }
+  }
+}
+
+// Global click listener for outside clicks
 document.addEventListener('click', (e) => {
   const toClose = [];
   for (const dropdown of openDropdowns) {
-    // Check if click is outside the dropdown container
-    // And also check if it's not the button itself (though button click usually stops propagation)
-    // We also check if target is contained in button (e.g. icon inside button)
-    const clickedInsideContainer = dropdown.container.contains(e.target);
-    const clickedButton = dropdown.btn === e.target || dropdown.btn.contains(e.target);
+    const clickedInsideContainer = dropdown.container && dropdown.container.contains(e.target);
+    const clickedMenu = dropdown.menu.contains(e.target);
+    const clickedButton = dropdown.btn && (dropdown.btn === e.target || dropdown.btn.contains(e.target));
 
-    if (!clickedInsideContainer && !clickedButton) {
+    if (!clickedMenu && !clickedButton && (!dropdown.container || !clickedInsideContainer)) {
       toClose.push(dropdown);
     }
   }
-
   toClose.forEach(d => closeDropdown(d));
 });
 
+// Global keydown listener
 document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') {
     closeAllDropdowns();
+    return;
+  }
+
+  // Handle navigation for the active dropdown
+  // We assume only one dropdown is open at a time usually
+  if (openDropdowns.size > 0) {
+    const lastOpened = Array.from(openDropdowns).pop(); // Get one
+
+    // Only handle nav if focus is within the menu or on the button
+    // Or if the menu is open.
+    // Actually, usually we want to trap focus or handle arrows if menu is open.
+    handleDropdownKeydown(e, lastOpened);
   }
 });
 
-export function initDropdown(btn, menu, container = null) {
-  if (!btn || !menu) return null;
+/**
+ * Registers a new dropdown.
+ * @param {string} id - Unique identifier for the dropdown.
+ * @param {Object} options - Configuration options.
+ * @param {HTMLElement} options.trigger - The button/element that toggles the dropdown.
+ * @param {HTMLElement} options.menu - The dropdown menu element.
+ * @param {HTMLElement} [options.container] - Optional container wrapping both.
+ * @param {Function} [options.onOpen] - Callback when opened.
+ * @param {Function} [options.onClose] - Callback when closed.
+ */
+export function registerDropdown(id, options) {
+  const { trigger, menu, container, onOpen, onClose } = options;
 
-  const dropdownContainer = container || menu.parentNode;
-  const dropdown = { btn, menu, container: dropdownContainer };
+  if (!trigger || !menu) {
+    console.error(`Dropdown ${id} missing trigger or menu`);
+    return null;
+  }
 
-  btn.addEventListener('click', (e) => {
+  // If already registered, update or return existing?
+  // For now, we'll overwrite the registry entry but we need to be careful about event listeners.
+  // Since we use global listeners and the object instance, we don't attach listeners to document per dropdown.
+  // We DO attach listener to the trigger.
+
+  const dropdown = {
+    id,
+    btn: trigger,
+    menu,
+    container: container || menu.parentNode,
+    onOpen,
+    onClose
+  };
+
+  // Remove old listener if re-registering?
+  // It's hard to remove anonymous function.
+  // We'll rely on the user to not register multiple times or we just add another listener which is bad.
+  // Ideally we should store the listener to remove it.
+
+  if (trigger._dropdownClickHandler) {
+      trigger.removeEventListener('click', trigger._dropdownClickHandler);
+  }
+
+  const clickHandler = (e) => {
     e.stopPropagation();
     toggleDropdown(dropdown);
-  });
+  };
+
+  trigger._dropdownClickHandler = clickHandler;
+  trigger.addEventListener('click', clickHandler);
+
+  // Ensure menu has basic a11y attributes
+  trigger.setAttribute('aria-haspopup', 'true');
+  trigger.setAttribute('aria-expanded', 'false');
+  // trigger.setAttribute('aria-controls', menu.id); // Assuming menu has ID, if not we could generate one but maybe skip for now
+
+  registry.set(id, dropdown);
 
   return {
     open: () => openDropdown(dropdown),
     close: () => closeDropdown(dropdown),
     toggle: () => toggleDropdown(dropdown)
   };
+}
+
+/**
+ * Legacy initializer for backward compatibility.
+ * Wraps registerDropdown.
+ */
+export function initDropdown(btn, menu, container = null) {
+  const id = btn.id ? `dropdown-${btn.id}` : `dropdown-${Math.random().toString(36).substr(2, 9)}`;
+  return registerDropdown(id, { trigger: btn, menu, container });
 }

--- a/src/modules/jules-free-input.js
+++ b/src/modules/jules-free-input.js
@@ -5,6 +5,7 @@ import { addToJulesQueue, handleQueueAction } from './jules-queue.js';
 import { RepoSelector, BranchSelector } from './repo-branch-selector.js';
 import { showToast } from './toast.js';
 import { JULES_MESSAGES, TIMEOUTS, RETRY_CONFIG } from '../utils/constants.js';
+import { registerDropdown } from './dropdown.js';
 
 let _lastSelectedSourceId = null;
 let _lastSelectedBranch = null;
@@ -323,28 +324,25 @@ export function showFreeInputForm() {
 
   const copenMenu = document.getElementById('freeInputCopenMenu');
   
-  copenBtn.onclick = (e) => {
-    e.stopPropagation();
-    copenMenu.style.display = copenMenu.style.display === 'none' ? 'block' : 'none';
-  };
-  
-  if (copenMenu) {
+  if (copenBtn && copenMenu) {
+    const copenDropdown = registerDropdown('free-input-copen-dropdown', {
+      trigger: copenBtn,
+      menu: copenMenu
+    });
+
     copenMenu.querySelectorAll('.custom-dropdown-item').forEach(item => {
-      item.onclick = async (e) => {
+      item.setAttribute('tabindex', '0');
+      item.setAttribute('role', 'menuitem');
+      item.addEventListener('click', async (e) => {
         e.stopPropagation();
         const target = item.dataset.target;
         await handleCopen(target);
-        copenMenu.style.display = 'none';
-      };
+        copenDropdown.close();
+      });
     });
   }
   
-  const closeCopenMenu = (e) => {
-    if (!copenBtn.contains(e.target) && !copenMenu.contains(e.target)) {
-      copenMenu.style.display = 'none';
-    }
-  };
-  document.addEventListener('click', closeCopenMenu);
+  // Previous manual listener 'closeCopenMenu' is removed as dropdown.js handles it.
 
   submitBtn.onclick = handleSubmit;
   queueBtn.onclick = handleQueue;

--- a/src/styles/components/content.css
+++ b/src/styles/components/content.css
@@ -260,3 +260,9 @@ a:hover { text-decoration: underline; }
 /* Danger zone variations */
 .danger-title { font-size:15px; font-weight:600; color:var(--danger); margin-bottom:10px; }
 .danger-desc { font-size:13px; color:var(--muted); margin-bottom:14px; }
+
+/* Unified Dropdown support for menu-panel */
+.menu-panel.open,
+.menu-panel.dropdown-open {
+  display: block;
+}

--- a/src/styles/components/dropdown.css
+++ b/src/styles/components/dropdown.css
@@ -43,6 +43,13 @@
 .custom-dropdown-item:last-child { border-bottom: none; }
 .custom-dropdown-item:hover { background: rgba(77, 217, 255, 0.08); color: var(--accent); }
 .custom-dropdown .custom-dropdown-menu .custom-dropdown-item:hover { background: rgba(77, 217, 255, 0.08); color: var(--accent); }
+.custom-dropdown-item:focus {
+    outline: none;
+    background: rgba(77, 217, 255, 0.08);
+    color: var(--accent);
+    box-shadow: inset 3px 0 0 var(--accent);
+}
+
 .custom-dropdown-item.selected { background: linear-gradient(135deg, rgba(77,217,255,0.2), rgba(77,217,255,0.1)); color: var(--accent); font-weight: 600; border-left: 3px solid var(--accent); }
 
 /* Utility: compact trigger width */
@@ -62,6 +69,7 @@
 .dropdown-item { display: flex; align-items: center; gap: 8px; }
 
 /* State for open dropdown */
-.custom-dropdown-menu.open {
+.custom-dropdown-menu.open,
+.custom-dropdown-menu.dropdown-open {
   display: block;
 }


### PR DESCRIPTION
- Update `src/modules/dropdown.js` to implement `registerDropdown` with centralized lifecycle management (open/close/toggle), outside click handling, and keyboard navigation.
- Update `src/styles/components/dropdown.css` and `src/styles/components/content.css` to support `.open` and `.dropdown-open` classes for visibility and focus styles.
- Refactor `src/modules/prompt-renderer.js` to use `registerDropdown`.
- Refactor `src/modules/jules-free-input.js` to use `registerDropdown`.
- Refactor `src/modules/repo-branch-selector.js` to use `registerDropdown`, removing manual event listeners and inline style manipulation.
- Ensure all dropdown items are keyboard accessible.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/b05a33a6-0b8c-46a8-b0d5-8ea828fd2ee1" />

---
https://jules.google.com/session/16149641764045445526