### PR TITLE
Refactor inline color styles to use semantic CSS classes

### DIFF
--- a/src/modules/jules-account.js
+++ b/src/modules/jules-account.js
@@ -43,7 +43,9 @@ export function showUserProfileModal() {
       julesKeyStatus.innerHTML = hasKey 
         ? '<span class="icon icon-inline" aria-hidden="true">check_circle</span> Saved'
         : '<span class="icon icon-inline" aria-hidden="true">cancel</span> Not saved';
-      julesKeyStatus.style.color = hasKey ? 'var(--accent)' : 'var(--muted)';
+      julesKeyStatus.style.color = '';
+      julesKeyStatus.classList.remove('status-saved', 'status-not-saved');
+      julesKeyStatus.classList.add(hasKey ? 'status-saved' : 'status-not-saved');
     }
     
     if (hasKey) {
@@ -84,7 +86,9 @@ export function showUserProfileModal() {
         if (deleted) {
           if (julesKeyStatus) {
             julesKeyStatus.innerHTML = '<span class="icon icon-inline" aria-hidden="true">cancel</span> Not saved';
-            julesKeyStatus.style.color = 'var(--muted)';
+            julesKeyStatus.style.color = '';
+            julesKeyStatus.classList.remove('status-saved', 'status-not-saved');
+            julesKeyStatus.classList.add('status-not-saved');
           }
           resetBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">delete</span> Delete Jules API Key';
           resetBtn.disabled = false;
@@ -474,7 +478,9 @@ export async function loadProfileDirectly(user) {
     julesKeyStatus.innerHTML = hasKey
       ? '<span class="icon icon-inline" aria-hidden="true">check_circle</span> Saved'
       : '<span class="icon icon-inline" aria-hidden="true">cancel</span> Not saved';
-    julesKeyStatus.style.color = hasKey ? 'var(--accent)' : 'var(--muted)';
+    julesKeyStatus.style.color = '';
+    julesKeyStatus.classList.remove('status-saved', 'status-not-saved');
+    julesKeyStatus.classList.add(hasKey ? 'status-saved' : 'status-not-saved');
   }
   
   if (hasKey) {
@@ -515,7 +521,9 @@ export async function loadProfileDirectly(user) {
         if (deleted) {
           if (julesKeyStatus) {
             julesKeyStatus.innerHTML = '<span class="icon icon-inline" aria-hidden="true">cancel</span> Not saved';
-            julesKeyStatus.style.color = 'var(--muted)';
+            julesKeyStatus.style.color = '';
+            julesKeyStatus.classList.remove('status-saved', 'status-not-saved');
+            julesKeyStatus.classList.add('status-not-saved');
           }
           resetBtn.innerHTML = originalResetLabel;
           resetBtn.disabled = false;

--- a/src/modules/repo-branch-selector.js
+++ b/src/modules/repo-branch-selector.js
@@ -227,7 +227,8 @@ export class RepoSelector {
 
   addShowMoreButton() {
     const showMoreBtn = document.createElement('div');
-    showMoreBtn.style.cssText = 'padding:8px; margin:4px 8px; text-align:center; border-top:1px solid var(--border); color:var(--accent); font-size:12px; cursor:pointer; font-weight:600;';
+    showMoreBtn.style.cssText = 'padding:8px; margin:4px 8px; text-align:center; border-top:1px solid var(--border); font-size:12px; cursor:pointer; font-weight:600;';
+    showMoreBtn.classList.add('status-action');
     showMoreBtn.textContent = '▼ Show more...';
     
     showMoreBtn.onclick = async () => {
@@ -562,7 +563,8 @@ export class BranchSelector {
     this.dropdownMenu.appendChild(currentItem);
     
     const showMoreBtn = document.createElement('div');
-    showMoreBtn.style.cssText = 'padding:8px; margin:4px 8px; text-align:center; border-top:1px solid var(--border); color:var(--accent); font-size:12px; cursor:pointer; font-weight:600;';
+    showMoreBtn.style.cssText = 'padding:8px; margin:4px 8px; text-align:center; border-top:1px solid var(--border); font-size:12px; cursor:pointer; font-weight:600;';
+    showMoreBtn.classList.add('status-action');
     showMoreBtn.textContent = '▼ Show more branches...';
     
     showMoreBtn.onclick = async () => {
@@ -581,7 +583,9 @@ export class BranchSelector {
 
         if (!allBranches || allBranches.length === 0) {
           showMoreBtn.textContent = allBranches === null ? 'GitHub API rate limited - try later' : 'No branches found';
-          showMoreBtn.style.color = 'var(--muted)';
+          showMoreBtn.style.color = '';
+          showMoreBtn.classList.remove('status-action');
+          showMoreBtn.classList.add('status-passive');
           showMoreBtn.style.pointerEvents = 'auto';
           return;
         }
@@ -606,7 +610,9 @@ export class BranchSelector {
       } catch (error) {
         console.error('Failed to load branches:', error);
         showMoreBtn.textContent = 'Failed to load - click to retry';
-        showMoreBtn.style.color = 'var(--muted)';
+        showMoreBtn.style.color = '';
+        showMoreBtn.classList.remove('status-action');
+        showMoreBtn.classList.add('status-passive');
         showMoreBtn.style.pointerEvents = 'auto';
       }
     };

--- a/src/pages/jules-page.js
+++ b/src/pages/jules-page.js
@@ -49,7 +49,9 @@ async function loadJulesInfo() {
       julesKeyStatus.innerHTML = hasKey 
         ? '<span class="icon icon-inline" aria-hidden="true">check_circle</span> Saved'
         : '<span class="icon icon-inline" aria-hidden="true">cancel</span> Not saved';
-      julesKeyStatus.style.color = hasKey ? 'var(--accent)' : 'var(--muted)';
+      julesKeyStatus.style.color = '';
+      julesKeyStatus.classList.remove('status-saved', 'status-not-saved');
+      julesKeyStatus.classList.add(hasKey ? 'status-saved' : 'status-not-saved');
     }
     
     loadingDiv.classList.add('hidden');
@@ -117,7 +119,9 @@ function initApp() {
           const julesKeyStatus = document.getElementById('julesKeyStatus');
           if (julesKeyStatus) {
             julesKeyStatus.innerHTML = '<span class="icon icon-inline" aria-hidden="true">cancel</span> Not saved';
-            julesKeyStatus.style.color = 'var(--muted)';
+            julesKeyStatus.style.color = '';
+            julesKeyStatus.classList.remove('status-saved', 'status-not-saved');
+            julesKeyStatus.classList.add('status-not-saved');
           }
           
           resetJulesKeyBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">delete</span> Delete Jules API Key';

--- a/src/shared-init.js
+++ b/src/shared-init.js
@@ -97,14 +97,16 @@ async function fetchVersion() {
       appVersion.style.background = '';
       appVersion.style.borderRadius = '';
       appVersion.style.padding = '';
-      appVersion.style.fontWeight = 'bold';
-      appVersion.style.color = '#ffe066'; // yellow text
+      appVersion.style.fontWeight = '';
+      appVersion.style.color = '';
+      appVersion.classList.add('status-outdated');
     } else {
       appVersion.textContent = `v${latestDateStr} (${latestSha})`;
       appVersion.style.background = '';
       appVersion.style.color = '';
       appVersion.style.borderRadius = '';
       appVersion.style.padding = '';
+      appVersion.classList.remove('status-outdated');
     }
     
     const dismissed = localStorage.getItem(`dismissed-version-${latestSha}`);

--- a/src/styles.css
+++ b/src/styles.css
@@ -20,6 +20,7 @@
 @import url('./styles/components/footer.css');
 @import url('./styles/components/split-modal.css');
 @import url('./styles/components/status-bar.css');
+@import url('./styles/components/status.css');
 @import url('./styles/components/tags.css');
 @import url('./styles/components/jules-profile.css');
 @import url('./styles/components/update-banner.css');

--- a/src/styles/components/status.css
+++ b/src/styles/components/status.css
@@ -1,0 +1,24 @@
+/* ===== Status Indicators ===== */
+/* Semantic classes for status colors replacing inline styles */
+
+.status-saved {
+  color: var(--accent);
+}
+
+.status-not-saved {
+  color: var(--muted);
+}
+
+.status-outdated {
+  color: #ffe066;
+  font-weight: bold; /* Moved from inline style in shared-init.js */
+}
+
+/* Interactive States (for repo-branch-selector) */
+.status-action {
+  color: var(--accent);
+}
+
+.status-passive {
+  color: var(--muted);
+}


### PR DESCRIPTION
Replaced inline `style.color` assignments with semantic CSS classes for status indicators and interactive elements.
- Created `src/styles/components/status.css` with `.status-saved`, `.status-not-saved`, `.status-outdated`, `.status-action`, `.status-passive`.
- Imported `status.css` in `src/styles.css`.
- Updated `src/modules/jules-account.js`, `src/pages/jules-page.js`, `src/shared-init.js`, and `src/modules/repo-branch-selector.js` to use these classes.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/1c0aebb0-1f4b-4698-ae42-25e285f6fb97" />

---
https://jules.google.com/session/7630281718490917647