### PR TITLE
Refactor visibility management to use CSS classes instead of inline styles.

### DIFF
--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -27,6 +27,7 @@ function openDropdown(dropdown) {
 
 function closeDropdown(dropdown) {
   dropdown.menu.classList.remove('open');
+  dropdown.menu.style.display = '';
   dropdown.btn.setAttribute('aria-expanded', 'false');
   openDropdowns.delete(dropdown);
 }

--- a/src/modules/jules-account.js
+++ b/src/modules/jules-account.js
@@ -10,6 +10,7 @@ import { showToast } from './toast.js';
 import { showConfirm } from './confirm-modal.js';
 import { attachPromptViewerHandlers } from './prompt-viewer.js';
 import { TIMEOUTS } from '../utils/constants.js';
+import { toggleVisibility } from '../utils/dom-helpers.js';
 
 let allSessionsCache = [];
 let sessionNextPageToken = null;
@@ -47,15 +48,15 @@ export function showUserProfileModal() {
     }
     
     if (hasKey) {
-      if (addBtn) addBtn.classList.add('d-none');
-      if (dangerZoneSection) dangerZoneSection.classList.remove('d-none');
-      if (julesProfileInfoSection) julesProfileInfoSection.classList.remove('d-none');
+      if (addBtn) toggleVisibility(addBtn, false);
+      if (dangerZoneSection) toggleVisibility(dangerZoneSection, true);
+      if (julesProfileInfoSection) toggleVisibility(julesProfileInfoSection, true);
       
       await loadAndDisplayJulesProfile(user.uid);
     } else {
-      if (addBtn) addBtn.classList.remove('d-none');
-      if (dangerZoneSection) dangerZoneSection.classList.add('d-none');
-      if (julesProfileInfoSection) julesProfileInfoSection.classList.add('d-none');
+      if (addBtn) toggleVisibility(addBtn, true);
+      if (dangerZoneSection) toggleVisibility(dangerZoneSection, false);
+      if (julesProfileInfoSection) toggleVisibility(julesProfileInfoSection, false);
     }
   });
 
@@ -89,9 +90,9 @@ export function showUserProfileModal() {
           resetBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">delete</span> Delete Jules API Key';
           resetBtn.disabled = false;
           
-          if (addBtn) addBtn.style.display = 'block';
-          if (dangerZoneSection) dangerZoneSection.style.display = 'none';
-          if (julesProfileInfoSection) julesProfileInfoSection.style.display = 'none';
+          if (addBtn) toggleVisibility(addBtn, true);
+          if (dangerZoneSection) toggleVisibility(dangerZoneSection, false);
+          if (julesProfileInfoSection) toggleVisibility(julesProfileInfoSection, false);
           
           showToast('Jules API key has been deleted. You can enter a new one next time.', 'success');
         } else {
@@ -202,14 +203,14 @@ async function loadAndDisplayJulesProfile(uid) {
           : '(no branches)';
 
         const branchesHtml = branches.length > 0
-          ? `<div id="${sourceId}-branches" style="display:none; margin-top:6px; padding-left:10px; font-size:11px; color:var(--muted);">
+          ? `<div id="${sourceId}-branches" class="hidden" style="margin-top:6px; padding-left:10px; font-size:11px; color:var(--muted);">
                <div style="margin-bottom:4px; color:var(--text);"><span class="icon icon-inline" aria-hidden="true">account_tree</span> Branches (${branches.length}):</div>
                ${branches.map(b => `<div style="padding:3px 0 3px 8px; cursor:pointer;"
                   onclick="window.open('https://github.com/${githubPath}/tree/${encodeURIComponent(b.displayName || b.name)}', '_blank')">
                   • ${b.displayName || b.name}
                 </div>`).join('')}
              </div>`
-          : `<div id="${sourceId}-branches" style="display:none; margin-top:6px; padding-left:10px; font-size:11px; color:var(--muted); font-style:italic;">No branches found</div>`;
+          : `<div id="${sourceId}-branches" class="hidden" style="margin-top:6px; padding-left:10px; font-size:11px; color:var(--muted); font-style:italic;">No branches found</div>`;
 
         const cardHtml = `
           <div class="queue-card">
@@ -219,8 +220,8 @@ async function loadAndDisplayJulesProfile(uid) {
                     onclick="(function(){
                       const el = document.getElementById('${sourceId}-branches');
                       const arrow = document.getElementById('${sourceId}-arrow');
-                      if (el.style.display === 'none') { el.style.display = 'block'; arrow.textContent = '▼'; }
-                      else { el.style.display = 'none'; arrow.textContent = '▶'; }
+                      if (el.classList.contains('hidden')) { el.classList.remove('hidden'); arrow.textContent = '▼'; }
+                      else { el.classList.add('hidden'); arrow.textContent = '▶'; }
                     })()">
                   <span id="${sourceId}-arrow" style="display:inline-block; width:12px; font-size:10px; margin-right:6px;">▶</span>
                   <span class="icon icon-inline" aria-hidden="true">folder</span> ${githubPath}
@@ -317,7 +318,7 @@ export function showJulesSessionsHistoryModal() {
   const modal = document.getElementById('julesSessionsHistoryModal');
   const searchInput = document.getElementById('sessionSearchInput');
   
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1002; flex-direction:column; align-items:center; justify-content:center; overflow-y:auto; padding:20px;');
+  modal.classList.add('show');
   
   allSessionsCache = [];
   sessionNextPageToken = null;
@@ -328,7 +329,8 @@ export function showJulesSessionsHistoryModal() {
 
 export function hideJulesSessionsHistoryModal() {
   const modal = document.getElementById('julesSessionsHistoryModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1002; flex-direction:column; align-items:center; justify-content:center; overflow-y:auto; padding:20px;');
+  modal.classList.remove('show');
+  modal.removeAttribute('style');
 }
 
 async function loadSessionsPage() {
@@ -357,11 +359,11 @@ async function loadSessionsPage() {
       renderAllSessions(allSessionsCache);
       
       if (sessionNextPageToken) {
-        loadMoreSection.style.display = 'block';
+        toggleVisibility(loadMoreSection, true);
         loadMoreBtn.disabled = false;
         loadMoreBtn.textContent = 'Load More';
       } else {
-        loadMoreSection.style.display = 'none';
+        toggleVisibility(loadMoreSection, false);
       }
     } else if (allSessionsCache.length === 0) {
       allSessionsList.innerHTML = '<div style="color:var(--muted); text-align:center; padding:24px;">No sessions found</div>';
@@ -478,15 +480,15 @@ export async function loadProfileDirectly(user) {
   }
   
   if (hasKey) {
-    if (addBtn) addBtn.style.display = 'none';
-    if (dangerZoneSection) dangerZoneSection.style.display = 'block';
-    if (julesProfileInfoSection) julesProfileInfoSection.style.display = 'block';
+    if (addBtn) toggleVisibility(addBtn, false);
+    if (dangerZoneSection) toggleVisibility(dangerZoneSection, true);
+    if (julesProfileInfoSection) toggleVisibility(julesProfileInfoSection, true);
     
     await loadAndDisplayJulesProfile(user.uid);
   } else {
-    if (addBtn) addBtn.style.display = 'block';
-    if (dangerZoneSection) dangerZoneSection.style.display = 'none';
-    if (julesProfileInfoSection) julesProfileInfoSection.style.display = 'none';
+    if (addBtn) toggleVisibility(addBtn, true);
+    if (dangerZoneSection) toggleVisibility(dangerZoneSection, false);
+    if (julesProfileInfoSection) toggleVisibility(julesProfileInfoSection, false);
   }
 
   // Attach event handlers
@@ -520,9 +522,9 @@ export async function loadProfileDirectly(user) {
           resetBtn.innerHTML = originalResetLabel;
           resetBtn.disabled = false;
           
-          if (addBtn) addBtn.style.display = 'block';
-          if (dangerZoneSection) dangerZoneSection.style.display = 'none';
-          if (julesProfileInfoSection) julesProfileInfoSection.style.display = 'none';
+          if (addBtn) toggleVisibility(addBtn, true);
+          if (dangerZoneSection) toggleVisibility(dangerZoneSection, false);
+          if (julesProfileInfoSection) toggleVisibility(julesProfileInfoSection, false);
           
           showToast('Jules API key has been deleted. You can enter a new one next time.', 'success');
         } else {
@@ -560,13 +562,13 @@ export async function loadJulesAccountInfo(user) {
   
   if (!hasKey) {
     if (julesProfileInfoSection) {
-      julesProfileInfoSection.style.display = 'none';
+      toggleVisibility(julesProfileInfoSection, false);
     }
     return;
   }
 
   if (julesProfileInfoSection) {
-    julesProfileInfoSection.style.display = 'block';
+    toggleVisibility(julesProfileInfoSection, true);
   }
 
   await loadAndDisplayJulesProfile(user.uid);

--- a/src/modules/jules-free-input.js
+++ b/src/modules/jules-free-input.js
@@ -5,6 +5,7 @@ import { addToJulesQueue, handleQueueAction } from './jules-queue.js';
 import { RepoSelector, BranchSelector } from './repo-branch-selector.js';
 import { showToast } from './toast.js';
 import { JULES_MESSAGES, TIMEOUTS, RETRY_CONFIG } from '../utils/constants.js';
+import { toggleVisibility } from '../utils/dom-helpers.js';
 
 let _lastSelectedSourceId = null;
 let _lastSelectedBranch = null;
@@ -61,16 +62,13 @@ export function showFreeInputForm() {
   const actions = document.getElementById('actions');
   const content = document.getElementById('content');
   
-  empty.classList.add('hidden');
-  if (title) title.style.display = 'none';
-  if (meta) meta.style.display = 'none';
-  if (actions) actions.style.display = 'none';
-  if (content) {
-    content.style.display = 'none';
-    content.classList.add('hidden');
-  }
+  toggleVisibility(empty, false);
+  toggleVisibility(title, false);
+  toggleVisibility(meta, false);
+  toggleVisibility(actions, false);
+  toggleVisibility(content, false);
   
-  freeInputSection.classList.remove('hidden');
+  toggleVisibility(freeInputSection, true);
   
   const textarea = document.getElementById('freeInputTextarea');
   const submitBtn = document.getElementById('freeInputSubmitBtn');
@@ -325,7 +323,8 @@ export function showFreeInputForm() {
   
   copenBtn.onclick = (e) => {
     e.stopPropagation();
-    copenMenu.style.display = copenMenu.style.display === 'none' ? 'block' : 'none';
+    const isHidden = copenMenu.classList.contains('hidden') || copenMenu.style.display === 'none';
+    toggleVisibility(copenMenu, isHidden);
   };
   
   if (copenMenu) {
@@ -334,14 +333,14 @@ export function showFreeInputForm() {
         e.stopPropagation();
         const target = item.dataset.target;
         await handleCopen(target);
-        copenMenu.style.display = 'none';
+        toggleVisibility(copenMenu, false);
       };
     });
   }
   
   const closeCopenMenu = (e) => {
     if (!copenBtn.contains(e.target) && !copenMenu.contains(e.target)) {
-      copenMenu.style.display = 'none';
+      toggleVisibility(copenMenu, false);
     }
   };
   document.addEventListener('click', closeCopenMenu);
@@ -366,14 +365,14 @@ export function hideFreeInputForm() {
   const actions = document.getElementById('actions');
   const content = document.getElementById('content');
   
-  freeInputSection.classList.add('hidden');
+  toggleVisibility(freeInputSection, false);
   
   // Restore the main content area elements
-  empty.classList.remove('hidden');
-  if (title) title.style.display = '';
-  if (meta) meta.style.display = '';
-  if (actions) actions.style.display = '';
-  if (content) content.style.display = '';
+  toggleVisibility(empty, true);
+  toggleVisibility(title, true);
+  toggleVisibility(meta, true);
+  toggleVisibility(actions, true);
+  toggleVisibility(content, true);
 }
 
 async function populateFreeInputRepoSelection() {

--- a/src/modules/jules-modal.js
+++ b/src/modules/jules-modal.js
@@ -7,6 +7,7 @@ import { addToJulesQueue } from './jules-queue.js';
 import { extractTitleFromPrompt } from '../utils/title.js';
 import { RETRY_CONFIG, TIMEOUTS, JULES_MESSAGES } from '../utils/constants.js';
 import { showToast } from './toast.js';
+import { toggleVisibility } from '../utils/dom-helpers.js';
 
 let lastSelectedSourceId = 'sources/github/promptroot/promptroot';
 let lastSelectedBranch = 'main';
@@ -28,7 +29,7 @@ export function openUrlInBackground(url) {
   a.href = url;
   a.target = '_blank';
   a.rel = 'noopener noreferrer';
-  a.style.display = 'none';
+  a.className = 'hidden';
   document.body.appendChild(a);
   
   const evt = new MouseEvent('click', {
@@ -50,7 +51,7 @@ export function showJulesKeyModal(onSave) {
   const modal = document.getElementById('julesKeyModal');
   const input = document.getElementById('julesKeyInput');
   
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.add('show');
   input.value = '';
   input.focus();
 
@@ -101,12 +102,13 @@ export function showJulesKeyModal(onSave) {
 
 export function hideJulesKeyModal() {
   const modal = document.getElementById('julesKeyModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.remove('show');
+  modal.removeAttribute('style');
 }
 
 export async function showJulesEnvModal(promptText) {
   const modal = document.getElementById('julesEnvModal');
-  modal.setAttribute('style', 'display: flex !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.add('show');
 
   const submitBtn = document.getElementById('julesEnvSubmitBtn');
   const queueBtn = document.getElementById('julesEnvQueueBtn');
@@ -299,7 +301,8 @@ async function handleRepoSelect(sourceId, branch, promptText, suppressPopups = f
 
 export function hideJulesEnvModal() {
   const modal = document.getElementById('julesEnvModal');
-  modal.setAttribute('style', 'display: none !important; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); z-index:1001; flex-direction:column; align-items:center; justify-content:center;');
+  modal.classList.remove('show');
+  modal.removeAttribute('style');
 }
 
 export async function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error, hideQueueButton = false) {
@@ -323,10 +326,8 @@ export async function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error,
     return { action: 'cancel', shouldDelay: false };
   }
 
-  if (hideQueueButton && queueBtn) {
-    queueBtn.style.display = 'none';
-  } else if (queueBtn) {
-    queueBtn.style.display = '';
+  if (queueBtn) {
+    toggleVisibility(queueBtn, !hideQueueButton);
   }
 
   return new Promise((resolve) => {
@@ -393,10 +394,10 @@ export function initJulesKeyModalListeners() {
 
   document.addEventListener('keydown', async (e) => {
     if (e.key === 'Escape') {
-      if (keyModal && keyModal.style.display === 'flex') {
+      if (keyModal && keyModal.classList.contains('show')) {
         hideJulesKeyModal();
       }
-      if (envModal && envModal.style.display === 'flex') {
+      if (envModal && envModal.classList.contains('show')) {
         hideJulesEnvModal();
       }
       const freeInputSection = document.getElementById('freeInputSection');
@@ -404,11 +405,11 @@ export function initJulesKeyModalListeners() {
         const { hideFreeInputForm } = await import('./jules-free-input.js?v=' + Date.now());
         hideFreeInputForm();
       }
-      if (profileModal && profileModal.style.display === 'flex') {
+      if (profileModal && profileModal.classList.contains('show')) {
         const { hideUserProfileModal } = await import('./jules-account.js');
         hideUserProfileModal();
       }
-      if (sessionsHistoryModal && sessionsHistoryModal.style.display === 'flex') {
+      if (sessionsHistoryModal && sessionsHistoryModal.classList.contains('show')) {
         const { hideJulesSessionsHistoryModal } = await import('./jules-account.js');
         hideJulesSessionsHistoryModal();
       }

--- a/src/modules/prompt-renderer.js
+++ b/src/modules/prompt-renderer.js
@@ -1,7 +1,7 @@
 import { slugify } from '../utils/slug.js';
 import { isGistUrl, resolveGistRawUrl, fetchGistContent, fetchRawFile } from './github-api.js';
 import { CODEX_URL_REGEX, TIMEOUTS } from '../utils/constants.js';
-import { setElementDisplay } from '../utils/dom-helpers.js';
+import { toggleVisibility } from '../utils/dom-helpers.js';
 import { ensureAncestorsExpanded, loadExpandedState, persistExpandedState, renderList, updateActiveItem, setCurrentSlug, getCurrentSlug, getFiles } from './prompt-list.js';
 import { showToast } from './toast.js';
 import statusBar from './status-bar.js';
@@ -77,7 +77,8 @@ function handleDocumentClick(event) {
   if (target === copenBtn) {
     event.stopPropagation();
     if (copenMenu) {
-      copenMenu.style.display = copenMenu.style.display === 'none' ? 'block' : 'none';
+      const isHidden = copenMenu.classList.contains('hidden') || copenMenu.style.display === 'none';
+      toggleVisibility(copenMenu, isHidden);
     }
     return;
   }
@@ -87,7 +88,7 @@ function handleDocumentClick(event) {
     event.stopPropagation();
     const targetApp = copenMenuItem.dataset.target;
     handleCopenPrompt(targetApp);
-    copenMenu.style.display = 'none';
+    toggleVisibility(copenMenu, false);
     return;
   }
 
@@ -114,7 +115,8 @@ function handleDocumentClick(event) {
   if (target === moreBtn) {
     event.stopPropagation();
     if (moreMenu) {
-      moreMenu.style.display = moreMenu.style.display === 'none' ? 'block' : 'none';
+      const isHidden = moreMenu.classList.contains('hidden') || moreMenu.style.display === 'none';
+      toggleVisibility(moreMenu, isHidden);
     }
     return;
   }
@@ -128,7 +130,7 @@ function handleDocumentClick(event) {
     if (editBtn && editBtn.href) {
       window.open(editBtn.href, '_blank', 'noopener,noreferrer');
     }
-    if (moreMenu) moreMenu.style.display = 'none';
+    if (moreMenu) toggleVisibility(moreMenu, false);
     return;
   }
 
@@ -137,7 +139,7 @@ function handleDocumentClick(event) {
     if (ghBtn && ghBtn.href) {
       window.open(ghBtn.href, '_blank', 'noopener,noreferrer');
     }
-    if (moreMenu) moreMenu.style.display = 'none';
+    if (moreMenu) toggleVisibility(moreMenu, false);
     return;
   }
 
@@ -146,19 +148,19 @@ function handleDocumentClick(event) {
     if (rawBtn && rawBtn.href) {
       window.open(rawBtn.href, '_blank', 'noopener,noreferrer');
     }
-    if (moreMenu) moreMenu.style.display = 'none';
+    if (moreMenu) toggleVisibility(moreMenu, false);
     return;
   }
 
-  if (copenMenu) copenMenu.style.display = 'none';
-  if (moreMenu) moreMenu.style.display = 'none';
+  if (copenMenu) toggleVisibility(copenMenu, false);
+  if (moreMenu) toggleVisibility(moreMenu, false);
 }
 
 async function handleBranchChanged() {
-  setElementDisplay(titleEl, false);
-  setElementDisplay(metaEl, false);
-  setElementDisplay(actionsEl, false);
-  setElementDisplay(emptyEl, false);
+  toggleVisibility(titleEl, false);
+  toggleVisibility(metaEl, false);
+  toggleVisibility(actionsEl, false);
+  toggleVisibility(emptyEl, false);
   if (contentEl) contentEl.innerHTML = '';
   setCurrentSlug(null);
   currentPromptText = null;
@@ -192,7 +194,7 @@ export async function selectBySlug(slug, files, owner, repo, branch) {
 export async function selectFile(f, pushHash, owner, repo, branch) {
   if (!f) {
     if (editBtn) {
-      editBtn.classList.add('hidden');
+      toggleVisibility(editBtn, false);
       editBtn.removeAttribute('href');
     }
     return;
@@ -203,19 +205,13 @@ export async function selectFile(f, pushHash, owner, repo, branch) {
     freeInputSection.classList.add('hidden');
   }
 
-  setElementDisplay(emptyEl, false);
-  setElementDisplay(titleEl, true);
-  setElementDisplay(metaEl, true);
-  setElementDisplay(actionsEl, true);
-  
-  // Clear inline styles that might have been set by showFreeInputForm
-  if (titleEl) titleEl.style.display = '';
-  if (metaEl) metaEl.style.display = '';
-  if (actionsEl) actionsEl.style.display = '';
+  toggleVisibility(emptyEl, false);
+  toggleVisibility(titleEl, true);
+  toggleVisibility(metaEl, true);
+  toggleVisibility(actionsEl, true);
   
   if (contentEl) {
-    contentEl.style.display = '';
-    contentEl.classList.remove('hidden');
+    toggleVisibility(contentEl, true);
   }
 
   titleEl.textContent = f.name.replace(/\.md$/i, '');

--- a/src/modules/repo-branch-selector.js
+++ b/src/modules/repo-branch-selector.js
@@ -142,8 +142,9 @@ export class RepoSelector {
   setupDropdownToggle() {
     this.dropdownBtn.onclick = async (e) => {
       e.stopPropagation();
-      if (this.dropdownMenu.style.display === 'block') {
-        this.dropdownMenu.style.display = 'none';
+      if (this.dropdownMenu.classList.contains('open') || this.dropdownMenu.style.display === 'block') {
+        this.dropdownMenu.classList.remove('open');
+        this.dropdownMenu.style.display = '';
         return;
       }
       
@@ -169,7 +170,8 @@ export class RepoSelector {
     loadingIndicator.style.cssText = 'padding:12px; text-align:center; color:var(--muted); font-size:13px;';
     loadingIndicator.textContent = 'Loading...';
     this.dropdownMenu.appendChild(loadingIndicator);
-    this.dropdownMenu.style.display = 'block';
+    this.dropdownMenu.classList.add('open');
+    this.dropdownMenu.style.display = '';
     
     await new Promise(resolve => setTimeout(resolve, 0));
     
@@ -183,7 +185,8 @@ export class RepoSelector {
       this.renderAllRepos();
     }
     
-    this.dropdownMenu.style.display = 'block';
+    this.dropdownMenu.classList.add('open');
+    this.dropdownMenu.style.display = '';
   }
 
   async renderFavorites() {
@@ -191,7 +194,8 @@ export class RepoSelector {
       const item = this.createRepoItem(fav.name, fav.id, true, async () => {
         this.selectedSourceId = fav.id;
         this.dropdownText.textContent = fav.name;
-        this.dropdownMenu.style.display = 'none';
+        this.dropdownMenu.classList.remove('open');
+        this.dropdownMenu.style.display = '';
         
         // Save repo selection
         this.saveToStorage();
@@ -296,7 +300,8 @@ export class RepoSelector {
       const item = this.createRepoItem(repoName, source.name || source.id, false, () => {
         this.selectedSourceId = source.name || source.id;
         this.dropdownText.textContent = repoName;
-        this.dropdownMenu.style.display = 'none';
+        this.dropdownMenu.classList.remove('open');
+        this.dropdownMenu.style.display = '';
         
         // Save repo selection
         this.saveToStorage();
@@ -328,7 +333,8 @@ export class RepoSelector {
       e.stopPropagation();
       if (isFavorite) {
         await this.removeFavorite(id);
-        this.dropdownMenu.style.display = 'none';
+        this.dropdownMenu.classList.remove('open');
+        this.dropdownMenu.style.display = '';
         setTimeout(() => this.populateDropdown(), 0);
       } else {
         const defaultBranch = extractDefaultBranch(this.allSources.find(s => (s.name || s.id) === id));
@@ -525,8 +531,9 @@ export class BranchSelector {
   setupDropdownToggle() {
     this.dropdownBtn.onclick = (e) => {
       e.stopPropagation();
-      if (this.dropdownMenu.style.display === 'block') {
-        this.dropdownMenu.style.display = 'none';
+      if (this.dropdownMenu.classList.contains('open') || this.dropdownMenu.style.display === 'block') {
+        this.dropdownMenu.classList.remove('open');
+        this.dropdownMenu.style.display = '';
         return;
       }
       
@@ -557,7 +564,8 @@ export class BranchSelector {
     currentItem.className = 'custom-dropdown-item selected';
     currentItem.textContent = this.selectedBranch;
     currentItem.onclick = () => {
-      this.dropdownMenu.style.display = 'none';
+      this.dropdownMenu.classList.remove('open');
+      this.dropdownMenu.style.display = '';
     };
     this.dropdownMenu.appendChild(currentItem);
     
@@ -598,7 +606,8 @@ export class BranchSelector {
           
           item.onclick = () => {
             this.setSelectedBranch(branch.name);
-            this.dropdownMenu.style.display = 'none';
+            this.dropdownMenu.classList.remove('open');
+            this.dropdownMenu.style.display = '';
           };
           
           this.dropdownMenu.appendChild(item);
@@ -613,7 +622,8 @@ export class BranchSelector {
     
     this.dropdownMenu.appendChild(showMoreBtn);
     
-    this.dropdownMenu.style.display = 'block';
+    this.dropdownMenu.classList.add('open');
+    this.dropdownMenu.style.display = '';
   }
 
   setSelectedBranch(branch) {

--- a/src/styles/components/modals.css
+++ b/src/styles/components/modals.css
@@ -1,6 +1,6 @@
 /* Modals & Jules Key Modal */
-#julesKeyModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1000; display: none !important; align-items: center; justify-content: center; }
-#julesKeyModal.show { display: flex !important; }
+#julesKeyModal, #julesEnvModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1000; display: none !important; align-items: center; justify-content: center; flex-direction: column; }
+#julesKeyModal.show, #julesEnvModal.show { display: flex !important; }
 #julesKeyModal > div { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; max-width: 400px; width: 90%; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); }
 #julesKeyModal h2 { margin: 0 0 12px; font-size: 18px; }
 #julesKeyModal p { margin: 0 0 16px; color: var(--muted); font-size: 13px; }
@@ -16,8 +16,8 @@
 #userProfileModal.show { display: flex !important; }
 
 /* All Sessions Modal specific */
-#allSessionsModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1002; display: none; flex-direction: column; align-items: center; justify-content: center; overflow-y: auto; padding: 20px; }
-#allSessionsModal.show { display: flex !important; }
+#allSessionsModal, #julesSessionsHistoryModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1002; display: none; flex-direction: column; align-items: center; justify-content: center; overflow-y: auto; padding: 20px; }
+#allSessionsModal.show, #julesSessionsHistoryModal.show { display: flex !important; }
 
 /* Edit Queue Modal specific */
 #editQueueItemModal { z-index: 1003; }

--- a/src/tests/test_visibility.mjs
+++ b/src/tests/test_visibility.mjs
@@ -1,0 +1,97 @@
+
+// Mock DOM
+class MockClassList {
+  constructor() {
+    this.classes = new Set();
+  }
+  add(cls) {
+    this.classes.add(cls);
+  }
+  remove(cls) {
+    this.classes.delete(cls);
+  }
+  toggle(cls, force) {
+    if (force !== undefined) {
+      if (force) this.add(cls);
+      else this.remove(cls);
+    } else {
+      if (this.classes.has(cls)) this.remove(cls);
+      else this.add(cls);
+    }
+  }
+  contains(cls) {
+    return this.classes.has(cls);
+  }
+}
+
+class MockElement {
+  constructor() {
+    this.classList = new MockClassList();
+    this.style = {};
+  }
+}
+
+global.document = {
+  createElement: () => new MockElement()
+};
+global.HTMLElement = MockElement;
+
+// Import the module
+import * as DomHelpers from '../utils/dom-helpers.js';
+
+console.log('Running tests for visibility helpers...');
+
+let failures = 0;
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`FAIL: ${message}`);
+    failures++;
+  } else {
+    console.log(`PASS: ${message}`);
+  }
+}
+
+async function runTests() {
+  // We expect toggleVisibility to exist
+  if (typeof DomHelpers.toggleVisibility !== 'function') {
+    console.error('FAIL: toggleVisibility function not found in exports');
+    failures++;
+  } else {
+    // Test 1: Hide element
+    const el1 = new MockElement();
+    DomHelpers.toggleVisibility(el1, false);
+    assert(el1.classList.contains('hidden'), 'Element should have hidden class when shouldShow=false');
+
+    // Test 2: Show element
+    const el2 = new MockElement();
+    el2.classList.add('hidden');
+    DomHelpers.toggleVisibility(el2, true);
+    assert(!el2.classList.contains('hidden'), 'Element should not have hidden class when shouldShow=true');
+
+    // Test 3: Null element check (should not crash)
+    try {
+      DomHelpers.toggleVisibility(null, true);
+      assert(true, 'Should handle null element gracefully');
+    } catch (e) {
+      assert(false, 'Threw error on null element');
+    }
+
+    // Test 4: Verify alias if setElementDisplay is kept/aliased
+    if (typeof DomHelpers.setElementDisplay === 'function') {
+         const el3 = new MockElement();
+         DomHelpers.setElementDisplay(el3, false);
+         assert(el3.classList.contains('hidden'), 'setElementDisplay should still work (via alias or existing)');
+    }
+  }
+
+  if (failures === 0) {
+    console.log('All tests passed!');
+    process.exit(0);
+  } else {
+    console.error(`${failures} tests failed.`);
+    process.exit(1);
+  }
+}
+
+runTests();

--- a/src/utils/dom-helpers.js
+++ b/src/utils/dom-helpers.js
@@ -11,11 +11,25 @@ export function createElement(tag, className = '', textContent = '') {
  * Toggles the visibility of an element by adding or removing the '.hidden' class.
  * Note: This relies on a global '.hidden' class with 'display: none !important;'.
  * @param {HTMLElement} el The element to show or hide.
+ * @param {boolean} shouldShow If true, the element will be shown; otherwise, it will be hidden.
+ */
+export function toggleVisibility(el, shouldShow = true) {
+  if (!el) return;
+  el.classList.toggle('hidden', !shouldShow);
+  if (shouldShow) {
+    el.style.display = '';
+  }
+}
+
+/**
+ * Toggles the visibility of an element by adding or removing the '.hidden' class.
+ * Note: This relies on a global '.hidden' class with 'display: none !important;'.
+ * @param {HTMLElement} el The element to show or hide.
  * @param {boolean} show If true, the element will be shown; otherwise, it will be hidden.
- * @deprecated Consider using `element.classList.toggle('hidden', !show)` directly for clarity.
+ * @deprecated Use toggleVisibility instead.
  */
 export function setElementDisplay(el, show = true) {
-  el.classList.toggle('hidden', !show);
+  toggleVisibility(el, show);
 }
 
 export function toggleClass(el, className, force) {


### PR DESCRIPTION
- Added `toggleVisibility` helper in `src/utils/dom-helpers.js`.
- Updated `src/modules/prompt-renderer.js` to use `toggleVisibility`.
- Updated `src/modules/jules-modal.js` to use `.show` class and cleaned up inline styles.
- Updated `src/modules/jules-account.js` to use `toggleVisibility` and class toggling.
- Updated `src/modules/jules-free-input.js` to use `toggleVisibility`.
- Updated `src/modules/repo-branch-selector.js` to use `.open` class for dropdowns.
- Updated `src/modules/dropdown.js` to ensure inline styles are cleared.
- Updated `src/styles/components/modals.css` to support missing modal IDs.
- Added unit tests in `src/tests/test_visibility.mjs`.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/2086b111-678b-4761-9eb4-6510d5a434f5" />

---
https://jules.google.com/session/3102923697494150032