### PR TITLE
Refactor: Remove setElementDisplay usage

### DIFF
--- a/docs/CODE_STYLE_GUIDE.md
+++ b/docs/CODE_STYLE_GUIDE.md
@@ -222,7 +222,6 @@ Located in `src/utils/dom-helpers.js`:
 ```javascript
 import { 
   createElement, 
-  setElementDisplay, 
   toggleClass, 
   clearElement, 
   onElement,
@@ -236,12 +235,6 @@ import {
 ```javascript
 const div = createElement('div', 'my-class', 'Text content');
 const button = createElement('button', 'btn primary');
-```
-
-**setElementDisplay(element, show)**
-```javascript
-setElementDisplay(element, true);  // Show
-setElementDisplay(element, false); // Hide
 ```
 
 **toggleClass(element, className, force)**
@@ -280,14 +273,6 @@ onElement(badge, 'click', (e) => {
 element.classList.add('hidden');      // Hide
 element.classList.remove('hidden');   // Show
 element.classList.toggle('hidden');   // Toggle
-```
-
-### Use Helper When Appropriate
-
-```javascript
-// ✅ Good: Helper function
-import { setElementDisplay } from '../utils/dom-helpers.js';
-setElementDisplay(element, isVisible);
 ```
 
 ### Avoid Direct Style Manipulation

--- a/src/modules/prompt-list.js
+++ b/src/modules/prompt-list.js
@@ -2,7 +2,7 @@ import { slugify } from '../utils/slug.js';
 import { STORAGE_KEYS, TAG_DEFINITIONS } from '../utils/constants.js';
 import { debounce } from '../utils/debounce.js';
 import { listPromptsViaContents, listPromptsViaTrees } from './github-api.js';
-import { clearElement, stopPropagation, setElementDisplay, toggleClass } from '../utils/dom-helpers.js';
+import { clearElement, stopPropagation, toggleClass } from '../utils/dom-helpers.js';
 import * as folderSubmenu from './folder-submenu.js';
 
 let files = [];

--- a/src/modules/prompt-renderer.js
+++ b/src/modules/prompt-renderer.js
@@ -1,7 +1,6 @@
 import { slugify } from '../utils/slug.js';
 import { isGistUrl, resolveGistRawUrl, fetchGistContent, fetchRawFile } from './github-api.js';
 import { CODEX_URL_REGEX, TIMEOUTS } from '../utils/constants.js';
-import { setElementDisplay } from '../utils/dom-helpers.js';
 import { ensureAncestorsExpanded, loadExpandedState, persistExpandedState, renderList, updateActiveItem, setCurrentSlug, getCurrentSlug, getFiles } from './prompt-list.js';
 import { showToast } from './toast.js';
 import statusBar from './status-bar.js';
@@ -155,10 +154,10 @@ function handleDocumentClick(event) {
 }
 
 async function handleBranchChanged() {
-  setElementDisplay(titleEl, false);
-  setElementDisplay(metaEl, false);
-  setElementDisplay(actionsEl, false);
-  setElementDisplay(emptyEl, false);
+  if (titleEl) titleEl.classList.add('hidden');
+  if (metaEl) metaEl.classList.add('hidden');
+  if (actionsEl) actionsEl.classList.add('hidden');
+  if (emptyEl) emptyEl.classList.add('hidden');
   if (contentEl) contentEl.innerHTML = '';
   setCurrentSlug(null);
   currentPromptText = null;
@@ -203,10 +202,10 @@ export async function selectFile(f, pushHash, owner, repo, branch) {
     freeInputSection.classList.add('hidden');
   }
 
-  setElementDisplay(emptyEl, false);
-  setElementDisplay(titleEl, true);
-  setElementDisplay(metaEl, true);
-  setElementDisplay(actionsEl, true);
+  if (emptyEl) emptyEl.classList.add('hidden');
+  if (titleEl) titleEl.classList.remove('hidden');
+  if (metaEl) metaEl.classList.remove('hidden');
+  if (actionsEl) actionsEl.classList.remove('hidden');
   
   // Clear inline styles that might have been set by showFreeInputForm
   if (titleEl) titleEl.style.display = '';

--- a/src/utils/dom-helpers.js
+++ b/src/utils/dom-helpers.js
@@ -7,17 +7,6 @@ export function createElement(tag, className = '', textContent = '') {
   return el;
 }
 
-/**
- * Toggles the visibility of an element by adding or removing the '.hidden' class.
- * Note: This relies on a global '.hidden' class with 'display: none !important;'.
- * @param {HTMLElement} el The element to show or hide.
- * @param {boolean} show If true, the element will be shown; otherwise, it will be hidden.
- * @deprecated Consider using `element.classList.toggle('hidden', !show)` directly for clarity.
- */
-export function setElementDisplay(el, show = true) {
-  el.classList.toggle('hidden', !show);
-}
-
 export function toggleClass(el, className, force) {
   if (force === undefined) {
     el.classList.toggle(className);


### PR DESCRIPTION
Replaces deprecated setElementDisplay helper with direct classList manipulation for visibility toggling.
- Updates prompt-renderer.js to use classList.add/remove('hidden')
- Removes setElementDisplay from dom-helpers.js
- Updates CODE_STYLE_GUIDE.md to recommend classList usage
- Removes unused import in prompt-list.js

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/43160d47-2ed9-4943-acdc-85051c85867e" />

---
https://jules.google.com/session/1428587563734554972