### PR TITLE
Refactor UI components to use createElement helpers instead of innerHTML strings

### DIFF
--- a/src/modules/confirm-modal.js
+++ b/src/modules/confirm-modal.js
@@ -1,35 +1,41 @@
 // ===== Confirmation Modal Module =====
 // Provides styled confirmation dialogs to replace confirm() calls
 
+import { createElement, createIconElement } from '../utils/dom-helpers.js';
+import { TIMEOUTS } from '../utils/constants.js';
+
 let confirmModal = null;
 let confirmResolve = null;
 
 function createConfirmModal() {
-  const modal = document.createElement('div');
-  modal.id = 'confirmModal';
-  modal.className = 'modal';
-  modal.style.zIndex = '10000';
-  modal.innerHTML = `
-    <div class="modal-content" style="max-width: 480px;">
-      <div class="modal-header">
-        <h3 id="confirmModalTitle">Confirm Action</h3>
-        <button class="btn-icon close-modal" id="confirmModalClose" title="Close">✕</button>
-      </div>
-      <div class="modal-body">
-        <p id="confirmModalMessage" style="line-height: 1.6; white-space: pre-wrap;"></p>
-      </div>
-      <div class="modal-buttons">
-        <button id="confirmModalCancel" class="btn">Cancel</button>
-        <button id="confirmModalConfirm" class="btn danger">Confirm</button>
-      </div>
-    </div>
-  `;
+  const modal = createElement('div', { id: 'confirmModal', class: 'modal', style: { zIndex: '10000' } });
+
+  const content = createElement('div', { class: 'modal-content', style: { maxWidth: '480px' } });
+
+  // Header
+  const header = createElement('div', { class: 'modal-header' });
+  header.appendChild(createElement('h3', { id: 'confirmModalTitle' }, 'Confirm Action'));
+
+  const closeBtn = createElement('button', { class: 'btn-icon close-modal', id: 'confirmModalClose', title: 'Close' }, '✕');
+  header.appendChild(closeBtn);
+  content.appendChild(header);
+
+  // Body
+  const body = createElement('div', { class: 'modal-body' });
+  body.appendChild(createElement('p', { id: 'confirmModalMessage', style: { lineHeight: '1.6', whiteSpace: 'pre-wrap' } }));
+  content.appendChild(body);
+
+  // Buttons
+  const buttons = createElement('div', { class: 'modal-buttons' });
+  buttons.appendChild(createElement('button', { id: 'confirmModalCancel', class: 'btn' }, 'Cancel'));
+  buttons.appendChild(createElement('button', { id: 'confirmModalConfirm', class: 'btn danger' }, 'Confirm'));
+  content.appendChild(buttons);
+
+  modal.appendChild(content);
   
   document.body.appendChild(modal);
   return modal;
 }
-
-import { TIMEOUTS } from '../utils/constants.js';
 
 function showConfirmModal() {
   if (!confirmModal) {

--- a/src/utils/dom-helpers.js
+++ b/src/utils/dom-helpers.js
@@ -1,10 +1,54 @@
 // ===== Common DOM Helpers =====
 
-export function createElement(tag, className = '', textContent = '') {
+export function createElement(tag, classNameOrAttrs = {}, textContentOrChildren = '') {
   const el = document.createElement(tag);
-  if (className) el.className = className;
-  if (textContent) el.textContent = textContent;
+
+  if (typeof classNameOrAttrs === 'string') {
+    // Old signature: (tag, className, textContent)
+    if (classNameOrAttrs) el.className = classNameOrAttrs;
+    if (textContentOrChildren) el.textContent = textContentOrChildren;
+  } else {
+    // New signature: (tag, attributes, children)
+    const attributes = classNameOrAttrs || {};
+    const children = textContentOrChildren;
+
+    for (const [key, value] of Object.entries(attributes)) {
+      if (key === 'className' || key === 'class') {
+        el.className = value;
+      } else if (key === 'textContent' || key === 'text') {
+        el.textContent = value;
+      } else if (key === 'style' && typeof value === 'object') {
+        Object.assign(el.style, value);
+      } else if (key === 'dataset' && typeof value === 'object') {
+        Object.assign(el.dataset, value);
+      } else if (key.startsWith('on') && typeof value === 'function') {
+        const eventName = key.substring(2).toLowerCase();
+        el.addEventListener(eventName, value);
+      } else if (key === 'html' || key === 'innerHTML') {
+        el.innerHTML = value;
+      } else if (value === true) {
+        el.setAttribute(key, '');
+      } else if (value !== false && value != null) {
+        el.setAttribute(key, value);
+      }
+    }
+
+    if (children) {
+      const childArray = Array.isArray(children) ? children : [children];
+      childArray.forEach(child => {
+        if (child instanceof Node) {
+          el.appendChild(child);
+        } else if (child != null && child !== false) {
+          el.appendChild(document.createTextNode(String(child)));
+        }
+      });
+    }
+  }
   return el;
+}
+
+export function createIconElement(iconName, className = 'icon-inline') {
+  return createElement('span', { class: `icon ${className}`, 'aria-hidden': 'true' }, iconName);
 }
 
 /**


### PR DESCRIPTION
Refactored `jules-account.js`, `jules-queue.js`, and `confirm-modal.js` to build DOM elements programmatically using an enhanced `createElement` utility. This improves security by reducing XSS risks and makes the code more maintainable.

- Upgraded `src/utils/dom-helpers.js`: `createElement` now supports attributes object and children array. Added `createIconElement`.
- Refactored `jules-account.js`: `loadAndDisplayJulesProfile` and `renderAllSessions` now use `createElement`.
- Refactored `jules-queue.js`: `openEditQueueModal`, `renderSubtasksList`, and `renderQueueList` now use `createElement`.
- Refactored `confirm-modal.js`: `createConfirmModal` now uses `createElement`.
- Maintained backward compatibility for `createElement`.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/1825eb7b-28fb-43af-b2c2-d40868c0c0fa" />

---
https://jules.google.com/session/16763004378650368916