### PR TITLE
Refactor jules-queue.js into focused modules

### DIFF
--- a/src/modules/jules-free-input.js
+++ b/src/modules/jules-free-input.js
@@ -1,7 +1,8 @@
 import { getCurrentUser } from './auth.js';
 import { checkJulesKey } from './jules-keys.js';
 import { showJulesKeyModal, showSubtaskErrorModal } from './jules-modal.js';
-import { addToJulesQueue, handleQueueAction } from './jules-queue.js';
+import { handleQueueAction } from './jules-queue.js';
+import { addToJulesQueue } from './jules-queue-api.js';
 import { RepoSelector, BranchSelector } from './repo-branch-selector.js';
 import { showToast } from './toast.js';
 import { JULES_MESSAGES, TIMEOUTS, RETRY_CONFIG } from '../utils/constants.js';

--- a/src/modules/jules-modal.js
+++ b/src/modules/jules-modal.js
@@ -3,7 +3,7 @@
 
 import { encryptAndStoreKey } from './jules-keys.js';
 import { RepoSelector, BranchSelector } from './repo-branch-selector.js';
-import { addToJulesQueue } from './jules-queue.js';
+import { addToJulesQueue } from './jules-queue-api.js';
 import { extractTitleFromPrompt } from '../utils/title.js';
 import { RETRY_CONFIG, TIMEOUTS, JULES_MESSAGES } from '../utils/constants.js';
 import { showToast } from './toast.js';

--- a/src/modules/jules-queue-api.js
+++ b/src/modules/jules-queue-api.js
@@ -1,0 +1,94 @@
+import { JULES_MESSAGES } from '../utils/constants.js';
+import { getCache, setCache, clearCache, CACHE_KEYS } from '../utils/session-cache.js';
+
+export async function addToJulesQueue(uid, queueItem) {
+  if (!window.db) throw new Error('Firestore not initialized');
+  try {
+    const collectionRef = window.db.collection('julesQueues').doc(uid).collection('items');
+    const docRef = await collectionRef.add({
+      ...queueItem,
+      autoOpen: queueItem.autoOpen !== false,
+      createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+      status: 'pending'
+    });
+    clearCache(CACHE_KEYS.QUEUE_ITEMS, uid);
+    return docRef.id;
+  } catch (err) {
+    console.error('Failed to add to queue', err);
+    throw err;
+  }
+}
+
+export async function updateJulesQueueItem(uid, docId, updates) {
+  if (!window.db) throw new Error('Firestore not initialized');
+  try {
+    const docRef = window.db.collection('julesQueues').doc(uid).collection('items').doc(docId);
+    await docRef.update(updates);
+    clearCache(CACHE_KEYS.QUEUE_ITEMS, uid);
+    return true;
+  } catch (err) {
+    console.error('Failed to update queue item', err);
+    throw err;
+  }
+}
+
+export async function deleteFromJulesQueue(uid, docId) {
+  if (!window.db) throw new Error('Firestore not initialized');
+  try {
+    await window.db.collection('julesQueues').doc(uid).collection('items').doc(docId).delete();
+    clearCache(CACHE_KEYS.QUEUE_ITEMS, uid);
+    return true;
+  } catch (err) {
+    console.error('Failed to delete queue item', err);
+    throw err;
+  }
+}
+
+export async function listJulesQueue(uid) {
+  if (!window.db) throw new Error('Firestore not initialized');
+  try {
+    const snapshot = await window.db.collection('julesQueues').doc(uid).collection('items').orderBy('createdAt', 'desc').get();
+    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+  } catch (err) {
+    console.error('Failed to list queue', err);
+    throw err;
+  }
+}
+
+export async function getUserTimeZone() {
+  const user = window.auth?.currentUser;
+  if (!user) return 'America/New_York';
+
+  try {
+    const profileDoc = await window.db.collection('userProfiles').doc(user.uid).get();
+    if (profileDoc.exists && profileDoc.data().preferredTimeZone) {
+      return profileDoc.data().preferredTimeZone;
+    }
+  } catch (err) {
+    console.warn('Failed to fetch user timezone preference', err);
+  }
+
+  const cached = getCache(CACHE_KEYS.USER_PROFILE, user.uid);
+  if (cached?.preferredTimeZone) {
+    return cached.preferredTimeZone;
+  }
+
+  return 'America/New_York';
+}
+
+export async function saveUserTimeZone(timeZone) {
+  const user = window.auth?.currentUser;
+  if (!user) return;
+
+  try {
+    await window.db.collection('userProfiles').doc(user.uid).set({
+      preferredTimeZone: timeZone,
+      updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+
+    const cached = getCache(CACHE_KEYS.USER_PROFILE, user.uid) || {};
+    setCache(CACHE_KEYS.USER_PROFILE, { ...cached, preferredTimeZone: timeZone }, user.uid);
+  } catch (err) {
+    console.warn('Failed to save timezone preference', err);
+  }
+}

--- a/src/modules/jules-queue-edit.js
+++ b/src/modules/jules-queue-edit.js
@@ -1,0 +1,482 @@
+import { RepoSelector, BranchSelector } from './repo-branch-selector.js';
+import { showToast } from './toast.js';
+import { showConfirm } from './confirm-modal.js';
+import { JULES_MESSAGES } from '../utils/constants.js';
+import { updateJulesQueueItem } from './jules-queue-api.js';
+import { escapeHtml } from './jules-queue-render.js';
+
+let editModalState = {
+  originalData: null,
+  hasUnsavedChanges: false,
+  currentDocId: null,
+  currentType: null,
+  repoSelector: null,
+  branchSelector: null,
+  isUnscheduled: false,
+  onSave: null
+};
+
+export async function openEditQueueModal(item, onSaveCallback) {
+  if (!item) {
+    showToast(JULES_MESSAGES.QUEUE_NOT_FOUND, 'error');
+    return;
+  }
+
+  editModalState.currentDocId = item.id;
+  editModalState.hasUnsavedChanges = false;
+  editModalState.onSave = onSaveCallback;
+
+  let modal = document.getElementById('editQueueItemModal');
+  if (!modal) {
+    modal = document.createElement('div');
+    modal.id = 'editQueueItemModal';
+    modal.className = 'modal-overlay';
+    modal.innerHTML = `
+      <div class="modal-dialog modal-dialog-lg">
+        <div class="modal-header">
+          <h2 class="modal-title">Edit Queue Item</h2>
+          <button class="btn-icon close-modal" id="closeEditQueueModal" title="Close"><span class="icon" aria-hidden="true">close</span></button>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <label class="form-section-label">Type:</label>
+            <div id="editQueueType" class="form-text"></div>
+          </div>
+          <div class="form-group" id="editQueueStatusGroup" class="hidden">
+            <label class="form-section-label">Schedule:</label>
+            <div id="editQueueScheduleInfo" class="form-text schedule-info-row">
+              <div id="editQueueScheduleText"></div>
+              <button type="button" id="unscheduleBtn" class="btn btn-secondary btn-xs">Unschedule</button>
+            </div>
+          </div>
+          <div class="form-group" id="editPromptGroup">
+            <div class="form-group-header">
+              <label class="form-section-label">Prompt:</label>
+              <button type="button" id="convertToSubtasksBtn" class="btn btn-secondary btn-xs">Split into Subtasks</button>
+            </div>
+            <textarea id="editQueuePrompt" class="form-control form-control-mono" rows="10"></textarea>
+          </div>
+          <div class="form-group" id="editSubtasksGroup" class="hidden">
+            <div class="form-group-header">
+              <label class="form-section-label">Subtasks:</label>
+              <button type="button" id="convertToSingleBtn" class="btn btn-secondary btn-xs hidden">Convert to Single Prompt</button>
+            </div>
+            <div id="editQueueSubtasksList"></div>
+          </div>
+          <div class="form-group">
+            <label class="form-section-label">Repository:</label>
+            <div id="editQueueRepoDropdown" class="custom-dropdown">
+              <button id="editQueueRepoDropdownBtn" class="custom-dropdown-btn w-full" type="button">
+                <span id="editQueueRepoDropdownText">Loading...</span>
+                <span class="custom-dropdown-caret" aria-hidden="true">▼</span>
+              </button>
+              <div id="editQueueRepoDropdownMenu" class="custom-dropdown-menu" role="menu"></div>
+            </div>
+          </div>
+          <div class="form-group space-below">
+            <label class="form-section-label">Branch:</label>
+            <div id="editQueueBranchDropdown" class="custom-dropdown">
+              <button id="editQueueBranchDropdownBtn" class="custom-dropdown-btn w-full" type="button">
+                <span id="editQueueBranchDropdownText">Loading branches...</span>
+                <span class="custom-dropdown-caret" aria-hidden="true">▼</span>
+              </button>
+              <div id="editQueueBranchDropdownMenu" class="custom-dropdown-menu" role="menu"></div>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button id="cancelEditQueue" class="btn">Cancel</button>
+          <button id="saveEditQueue" class="btn primary">Save</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(modal);
+
+    document.getElementById('closeEditQueueModal').onclick = () => closeEditModal();
+    document.getElementById('cancelEditQueue').onclick = () => closeEditModal();
+
+    modal.onclick = (e) => {
+      if (e.target === modal) {
+        closeEditModal();
+      }
+    };
+
+    document.getElementById('saveEditQueue').onclick = async () => {
+      await saveQueueItemEdit();
+    };
+    setupSubtasksEventDelegation();
+  }
+
+  const typeDiv = document.getElementById('editQueueType');
+  const promptGroup = document.getElementById('editPromptGroup');
+  const subtasksGroup = document.getElementById('editSubtasksGroup');
+  const promptTextarea = document.getElementById('editQueuePrompt');
+  const repoDropdownBtn = document.getElementById('editQueueRepoDropdownBtn');
+  const repoDropdownText = document.getElementById('editQueueRepoDropdownText');
+  const repoDropdownMenu = document.getElementById('editQueueRepoDropdownMenu');
+  const branchDropdownBtn = document.getElementById('editQueueBranchDropdownBtn');
+  const branchDropdownText = document.getElementById('editQueueBranchDropdownText');
+  const branchDropdownMenu = document.getElementById('editQueueBranchDropdownMenu');
+
+  if (item.type === 'single') {
+    typeDiv.textContent = 'Single Prompt';
+    promptGroup.classList.remove('hidden');
+    subtasksGroup.classList.add('hidden');
+    promptTextarea.value = item.prompt || '';
+    editModalState.originalData = { prompt: item.prompt || '' };
+    editModalState.currentType = 'single';
+
+    document.getElementById('convertToSubtasksBtn').onclick = convertToSubtasks;
+  } else if (item.type === 'subtasks') {
+    typeDiv.textContent = 'Subtasks Batch';
+    promptGroup.classList.add('hidden');
+    subtasksGroup.classList.remove('hidden');
+
+    const subtasks = item.remaining || [];
+    renderSubtasksList(subtasks);
+
+    editModalState.originalData = {
+      subtasks: subtasks.map(s => s.fullContent || '')
+    };
+    editModalState.currentType = 'subtasks';
+
+    document.getElementById('convertToSingleBtn').onclick = convertToSingle;
+    updateConvertToSingleButtonVisibility();
+  }
+
+  editModalState.originalData.sourceId = item.sourceId || '';
+  editModalState.originalData.branch = item.branch || 'master';
+
+  displayScheduleStatus(item);
+
+  await initializeEditRepoAndBranch(item.sourceId, item.branch || 'master', repoDropdownBtn, repoDropdownText, repoDropdownMenu, branchDropdownBtn, branchDropdownText, branchDropdownMenu);
+
+  modal.style.display = 'flex';
+
+  const trackChanges = () => {
+    editModalState.hasUnsavedChanges = true;
+  };
+
+  if (promptTextarea) {
+    promptTextarea.oninput = trackChanges;
+  }
+}
+
+export async function closeEditModal(force = false) {
+  const modal = document.getElementById('editQueueItemModal');
+  if (!modal) return;
+
+  if (!force && editModalState.hasUnsavedChanges) {
+    const confirmed = await showConfirm('You have unsaved changes. Are you sure you want to close?', {
+      title: 'Unsaved Changes',
+      confirmText: 'Close Anyway',
+      confirmStyle: 'warn'
+    });
+    if (!confirmed) return;
+  }
+  modal.style.display = 'none';
+  editModalState.hasUnsavedChanges = false;
+  editModalState.originalData = null;
+  editModalState.currentDocId = null;
+  editModalState.currentType = null;
+  editModalState.repoSelector = null;
+  editModalState.branchSelector = null;
+  editModalState.isUnscheduled = false;
+  editModalState.onSave = null;
+}
+
+async function saveQueueItemEdit() {
+  const docId = editModalState.currentDocId;
+  const user = window.auth?.currentUser;
+
+  if (!docId || !user) {
+    showToast(JULES_MESSAGES.NOT_SIGNED_IN, 'error');
+    return;
+  }
+
+  try {
+    const sourceId = editModalState.repoSelector?.getSelectedSourceId();
+    const branch = editModalState.branchSelector?.getSelectedBranch();
+
+    const updates = {
+      sourceId: sourceId || editModalState.originalData.sourceId,
+      branch: branch || editModalState.originalData.branch || 'master',
+      updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+    };
+
+    if (editModalState.isUnscheduled) {
+      updates.status = 'pending';
+      updates.scheduledAt = firebase.firestore.FieldValue.delete();
+      updates.scheduledTimeZone = firebase.firestore.FieldValue.delete();
+      updates.activatedAt = firebase.firestore.FieldValue.delete();
+    }
+
+    const currentType = editModalState.currentType;
+
+    if (currentType === 'single') {
+      const promptTextarea = document.getElementById('editQueuePrompt');
+      updates.type = 'single';
+      updates.prompt = promptTextarea.value;
+      // We don't have access to original item here to check if it was 'subtasks' before.
+      // But we can delete the subtasks fields anyway if we are switching to single.
+      // Firestore merge will handle it, but field deletion needs explicit instruction.
+      // We'll just set them to delete if we switched types or just always cleanup.
+      // The original code checked 'if (item.type === subtasks)'.
+      // We can rely on editModalState.originalData logic or just always clean up opposite fields?
+      // Or we can fetch the item again? No.
+      // Let's assume we want to clean up.
+      updates.remaining = firebase.firestore.FieldValue.delete();
+      updates.totalCount = firebase.firestore.FieldValue.delete();
+    } else if (currentType === 'subtasks') {
+      const subtaskTextareas = document.querySelectorAll('.edit-subtask-content');
+      const updatedSubtasks = Array.from(subtaskTextareas).map(textarea => ({
+        fullContent: textarea.value
+      }));
+      updates.type = 'subtasks';
+      updates.remaining = updatedSubtasks;
+      updates.totalCount = updatedSubtasks.length;
+      updates.prompt = firebase.firestore.FieldValue.delete();
+    }
+
+    await updateJulesQueueItem(user.uid, docId, updates);
+
+    showToast(JULES_MESSAGES.QUEUE_UPDATED, 'success');
+    editModalState.hasUnsavedChanges = false;
+
+    if (editModalState.onSave) {
+      editModalState.onSave(true);
+    }
+
+    closeEditModal(true); // force close
+  } catch (err) {
+    showToast(JULES_MESSAGES.QUEUE_UPDATE_FAILED(err.message), 'error');
+  }
+}
+
+async function initializeEditRepoAndBranch(sourceId, branch, repoDropdownBtn, repoDropdownText, repoDropdownMenu, branchDropdownBtn, branchDropdownText, branchDropdownMenu) {
+  const branchSelector = new BranchSelector({
+    dropdownBtn: branchDropdownBtn,
+    dropdownText: branchDropdownText,
+    dropdownMenu: branchDropdownMenu,
+    onSelect: (selectedBranch) => {
+      editModalState.hasUnsavedChanges = true;
+    }
+  });
+
+  const repoSelector = new RepoSelector({
+    dropdownBtn: repoDropdownBtn,
+    dropdownText: repoDropdownText,
+    dropdownMenu: repoDropdownMenu,
+    branchSelector: branchSelector,
+    onSelect: (selectedSourceId) => {
+      editModalState.hasUnsavedChanges = true;
+    }
+  });
+
+  editModalState.repoSelector = repoSelector;
+  editModalState.branchSelector = branchSelector;
+
+  await repoSelector.initialize(sourceId, branch);
+}
+
+function setupSubtasksEventDelegation() {
+  const subtasksList = document.getElementById('editQueueSubtasksList');
+  if (!subtasksList) return;
+
+  if (subtasksList.dataset.listenerAttached) return;
+  subtasksList.dataset.listenerAttached = 'true';
+
+  subtasksList.addEventListener('click', (event) => {
+    const target = event.target;
+
+    if (target.classList.contains('add-subtask-btn')) {
+      addNewSubtask();
+      return;
+    }
+
+    const removeBtn = target.closest('.remove-subtask-btn');
+    if (removeBtn) {
+      const index = parseInt(removeBtn.dataset.index);
+      removeSubtask(index);
+      return;
+    }
+  });
+
+  subtasksList.addEventListener('input', (event) => {
+    if (event.target.classList.contains('edit-subtask-content')) {
+      editModalState.hasUnsavedChanges = true;
+    }
+  });
+}
+
+function displayScheduleStatus(item) {
+  const statusGroup = document.getElementById('editQueueStatusGroup');
+  const scheduleText = document.getElementById('editQueueScheduleText');
+  const unscheduleBtn = document.getElementById('unscheduleBtn');
+
+  if (!statusGroup || !scheduleText) return;
+
+  if (item.status === 'scheduled' && item.scheduledAt) {
+    const scheduledDate = new Date(item.scheduledAt.seconds * 1000);
+    const timeZone = item.scheduledTimeZone || 'America/New_York';
+    const dateStr = scheduledDate.toLocaleString('en-US', {
+      timeZone: timeZone,
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+    scheduleText.textContent = `Scheduled for ${dateStr} (${timeZone})`;
+    statusGroup.classList.remove('hidden');
+
+    if (unscheduleBtn) {
+      unscheduleBtn.onclick = () => {
+        unscheduleQueueItem();
+      };
+    }
+  } else {
+    statusGroup.classList.add('hidden');
+  }
+}
+
+function unscheduleQueueItem() {
+  const statusGroup = document.getElementById('editQueueStatusGroup');
+  if (statusGroup) {
+    statusGroup.classList.add('hidden');
+  }
+
+  editModalState.isUnscheduled = true;
+  editModalState.hasUnsavedChanges = true;
+
+  showToast('Item marked for unscheduling. Click Save to confirm.', 'info');
+}
+
+function convertToSubtasks() {
+  const promptTextarea = document.getElementById('editQueuePrompt');
+  const promptContent = promptTextarea.value.trim();
+
+  const promptGroup = document.getElementById('editPromptGroup');
+  const subtasksGroup = document.getElementById('editSubtasksGroup');
+  const typeDiv = document.getElementById('editQueueType');
+
+  promptGroup.classList.add('hidden');
+  subtasksGroup.classList.remove('hidden');
+  typeDiv.textContent = 'Subtasks Batch';
+
+  const subtasks = promptContent ? [{ fullContent: promptContent }] : [{ fullContent: '' }];
+  renderSubtasksList(subtasks);
+
+  editModalState.currentType = 'subtasks';
+  editModalState.hasUnsavedChanges = true;
+
+  document.getElementById('convertToSingleBtn').onclick = convertToSingle;
+  updateConvertToSingleButtonVisibility();
+}
+
+async function convertToSingle() {
+  const currentSubtasks = Array.from(document.querySelectorAll('.edit-subtask-content')).map(textarea => textarea.value);
+
+  if (currentSubtasks.length > 1) {
+    const confirmed = await showConfirm('This will combine all subtasks into a single prompt. Continue?', {
+      title: 'Convert to Single Prompt',
+      confirmText: 'Convert',
+      confirmStyle: 'warn'
+    });
+    if (!confirmed) return;
+  }
+
+  const promptGroup = document.getElementById('editPromptGroup');
+  const subtasksGroup = document.getElementById('editSubtasksGroup');
+  const typeDiv = document.getElementById('editQueueType');
+  const promptTextarea = document.getElementById('editQueuePrompt');
+
+  const combinedPrompt = currentSubtasks.join('\n\n---\n\n');
+
+  subtasksGroup.classList.add('hidden');
+  promptGroup.classList.remove('hidden');
+  typeDiv.textContent = 'Single Prompt';
+  promptTextarea.value = combinedPrompt;
+
+  editModalState.currentType = 'single';
+  editModalState.hasUnsavedChanges = true;
+
+  document.getElementById('convertToSubtasksBtn').onclick = convertToSubtasks;
+}
+
+function updateConvertToSingleButtonVisibility() {
+  const convertBtn = document.getElementById('convertToSingleBtn');
+  const subtaskCount = document.querySelectorAll('.edit-subtask-content').length;
+
+  if (convertBtn) {
+    if (subtaskCount === 1) {
+      convertBtn.classList.remove('hidden');
+    } else {
+      convertBtn.classList.add('hidden');
+    }
+  }
+}
+
+function renderSubtasksList(subtasks) {
+  const subtasksList = document.getElementById('editQueueSubtasksList');
+  if (!subtasksList) {
+    console.error('editQueueSubtasksList element not found');
+    return;
+  }
+
+  subtasksList.innerHTML = subtasks.map((subtask, index) => `
+    <div class="form-group subtask-item" data-index="${index}">
+      <div class="subtask-item-header">
+        <label class="form-label">Subtask ${index + 1}:</label>
+        <button type="button" class="remove-subtask-btn" data-index="${index}" title="Remove this subtask"><span class="icon" aria-hidden="true">close</span></button>
+      </div>
+      <textarea class="form-control edit-subtask-content" rows="5">${escapeHtml(subtask.fullContent || '')}</textarea>
+    </div>
+  `).join('');
+
+  const addButton = document.createElement('button');
+  addButton.type = 'button';
+  addButton.className = 'btn btn-secondary add-subtask-btn';
+  addButton.textContent = '+ Add Subtask';
+  subtasksList.appendChild(addButton);
+
+  updateConvertToSingleButtonVisibility();
+}
+
+function addNewSubtask() {
+  const currentSubtasks = Array.from(document.querySelectorAll('.edit-subtask-content')).map(textarea => ({
+    fullContent: textarea.value
+  }));
+
+  currentSubtasks.push({ fullContent: '' });
+
+  renderSubtasksList(currentSubtasks);
+
+  editModalState.hasUnsavedChanges = true;
+
+  const textareas = document.querySelectorAll('.edit-subtask-content');
+  if (textareas.length > 0) {
+    textareas[textareas.length - 1].focus();
+  }
+}
+
+async function removeSubtask(index) {
+  const currentSubtasks = Array.from(document.querySelectorAll('.edit-subtask-content')).map(textarea => ({
+    fullContent: textarea.value
+  }));
+
+  if (currentSubtasks.length <= 1) {
+    const confirmed = await showConfirm('This is the last subtask. Removing it will leave no subtasks. Continue?', {
+      title: 'Remove Last Subtask',
+      confirmText: 'Remove',
+      confirmStyle: 'warn'
+    });
+    if (!confirmed) return;
+  }
+
+  currentSubtasks.splice(index, 1);
+
+  renderSubtasksList(currentSubtasks);
+
+  editModalState.hasUnsavedChanges = true;
+}

--- a/src/modules/jules-queue-render.js
+++ b/src/modules/jules-queue-render.js
@@ -1,0 +1,115 @@
+export function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+export function renderQueueList(items) {
+  const listDiv = document.getElementById('allQueueList');
+  if (!listDiv) return;
+  if (!items || items.length === 0) {
+    listDiv.innerHTML = '<div class="panel text-center pad-xl muted-text">No queued items.</div>';
+    return;
+  }
+
+  listDiv.innerHTML = items.map(item => {
+    const created = item.createdAt ? new Date(item.createdAt.seconds ? item.createdAt.seconds * 1000 : item.createdAt).toLocaleString() : 'Unknown';
+    const status = item.status || 'pending';
+    const remainingCount = Array.isArray(item.remaining) ? item.remaining.length : 0;
+
+    let scheduledInfo = '';
+    if (status === 'scheduled' && item.scheduledAt) {
+      const scheduledDate = new Date(item.scheduledAt.seconds * 1000);
+      const timeZone = item.scheduledTimeZone || 'America/New_York';
+      const dateStr = scheduledDate.toLocaleString('en-US', {
+        timeZone: timeZone,
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+      const retryCount = item.retryCount || 0;
+      const retryInfo = retryCount > 0 ? ` (Retry ${retryCount}/3)` : '';
+      scheduledInfo = `<div class="queue-scheduled-info"><span class="icon icon-inline" aria-hidden="true">schedule</span> Scheduled: ${dateStr} (${timeZone})${retryInfo}</div>`;
+    }
+
+    let errorInfo = '';
+    if (status === 'error' && item.error) {
+      errorInfo = `<div class="queue-error-info"><span class="icon icon-inline" aria-hidden="true">error</span> ${escapeHtml(item.error)}</div>`;
+    } else if (status === 'scheduled' && item.lastError && item.retryCount > 0) {
+      errorInfo = `<div class="queue-error-info"><span class="icon icon-inline" aria-hidden="true">warning</span> Last attempt failed: ${escapeHtml(item.lastError)}</div>`;
+    }
+
+    if (item.type === 'subtasks' && Array.isArray(item.remaining) && item.remaining.length > 0) {
+      const subtasksHtml = item.remaining.map((subtask, index) => {
+        const preview = (subtask.fullContent || '').substring(0, 150);
+        return `
+          <div class="queue-subtask">
+            <div class="queue-subtask-index">
+              <input class="subtask-checkbox" type="checkbox" data-docid="${item.id}" data-index="${index}" />
+            </div>
+            <div class="queue-subtask-content">
+              <div class="queue-subtask-meta">Subtask ${index + 1} of ${item.remaining.length}</div>
+              <div class="queue-subtask-text">${escapeHtml(preview)}${preview.length >= 150 ? '...' : ''}</div>
+            </div>
+          </div>
+        `;
+      }).join('');
+
+      const repoDisplay = item.sourceId ? `<div class="queue-repo"><span class="icon icon-inline" aria-hidden="true">inventory_2</span> ${item.sourceId.split('/').slice(-2).join('/')} (${item.branch || 'master'})</div>` : '';
+
+      const statusClass = status === 'scheduled' ? 'queue-status-scheduled' : '';
+
+      return `
+        <div class="queue-card queue-item ${statusClass}" data-docid="${item.id}">
+          <div class="queue-row">
+            <div class="queue-checkbox-col">
+              <input class="queue-checkbox" type="checkbox" data-docid="${item.id}" />
+            </div>
+            <div class="queue-content">
+              <div class="queue-title">
+                Subtasks Batch <span class="queue-status">${status}</span>
+                <span class="queue-status">(${remainingCount} remaining)</span>
+                <button class="btn-icon edit-queue-item" data-docid="${item.id}" title="Edit queue item"><span class="icon icon-inline" aria-hidden="true">edit</span></button>
+              </div>
+              <div class="queue-meta">Created: ${created} • ID: <span class="mono">${item.id}</span></div>
+              ${repoDisplay}
+              ${scheduledInfo}
+              ${errorInfo}
+            </div>
+          </div>
+          <div class="queue-subtasks">
+            ${subtasksHtml}
+          </div>
+        </div>
+      `;
+    }
+
+    const promptPreview = (item.prompt || '').substring(0, 200);
+    const repoDisplay = item.sourceId ? `<div class="queue-repo"><span class="icon icon-inline" aria-hidden="true">inventory_2</span> ${item.sourceId.split('/').slice(-2).join('/')} (${item.branch || 'master'})</div>` : '';
+
+    const statusClass = status === 'scheduled' ? 'queue-status-scheduled' : '';
+
+    return `
+      <div class="queue-card queue-item ${statusClass}" data-docid="${item.id}">
+        <div class="queue-row">
+          <div class="queue-checkbox-col">
+            <input class="queue-checkbox" type="checkbox" data-docid="${item.id}" />
+          </div>
+          <div class="queue-content">
+            <div class="queue-title">
+              Single Prompt <span class="queue-status">${status}</span>
+              <button class="btn-icon edit-queue-item" data-docid="${item.id}" title="Edit queue item"><span class="icon icon-inline" aria-hidden="true">edit</span></button>
+            </div>
+            <div class="queue-meta">Created: ${created} • ID: <span class="mono">${item.id}</span></div>
+            ${repoDisplay}
+            ${scheduledInfo}
+            ${errorInfo}
+            <div class="queue-prompt">${escapeHtml(promptPreview)}${promptPreview.length >= 200 ? '...' : ''}</div>
+          </div>
+        </div>
+      </div>
+    `;
+  }).join('');
+}

--- a/src/modules/jules-queue-schedule.js
+++ b/src/modules/jules-queue-schedule.js
@@ -1,0 +1,275 @@
+import { showToast } from './toast.js';
+import { JULES_MESSAGES } from '../utils/constants.js';
+import { updateJulesQueueItem, getUserTimeZone, saveUserTimeZone } from './jules-queue-api.js';
+
+let scheduleState = {
+  selectedIds: [],
+  onSchedule: null
+};
+
+export async function showScheduleModal(selectedIds, onScheduleCallback) {
+  const user = window.auth?.currentUser;
+  if (!user) {
+    showToast(JULES_MESSAGES.SIGN_IN_REQUIRED, 'warn');
+    return;
+  }
+
+  scheduleState.selectedIds = selectedIds;
+  scheduleState.onSchedule = onScheduleCallback;
+
+  const userTimeZone = await getUserTimeZone();
+
+  let modal = document.getElementById('scheduleQueueModal');
+  if (!modal) {
+    await loadScheduleModal();
+    modal = document.getElementById('scheduleQueueModal');
+    if (!modal) {
+      console.error('Failed to load schedule modal');
+      return;
+    }
+  }
+
+  populateTimeZoneDropdown(userTimeZone);
+  initializeScheduleModalInputs();
+  attachScheduleModalHandlers();
+
+  modal.style.display = 'flex';
+}
+
+async function loadScheduleModal() {
+  const container = document.getElementById('scheduleQueueModalContainer');
+  if (!container) {
+    console.error('Schedule modal container not found');
+    return;
+  }
+
+  try {
+    const response = await fetch('/partials/schedule-queue-modal.html');
+    if (!response.ok) throw new Error('Failed to load modal');
+    const html = await response.text();
+    container.innerHTML = html;
+  } catch (err) {
+    console.error('Error loading schedule modal:', err);
+  }
+}
+
+function populateTimeZoneDropdown(selectedTimeZone) {
+  const tzSelect = document.getElementById('scheduleTimeZone');
+  if (!tzSelect) return;
+
+  const timeZones = getCommonTimeZones();
+  tzSelect.innerHTML = timeZones.map(tz =>
+    `<option value="${tz.value}" ${tz.value === selectedTimeZone ? 'selected' : ''}>${tz.label}</option>`
+  ).join('');
+}
+
+function initializeScheduleModalInputs() {
+  const dateInput = document.getElementById('scheduleDate');
+  const timeInput = document.getElementById('scheduleTime');
+  const tzSelect = document.getElementById('scheduleTimeZone');
+
+  const updateMinDate = () => {
+    if (!dateInput || !tzSelect) return;
+
+    const selectedTz = tzSelect.value;
+    const nowInTz = new Date().toLocaleString('en-US', { timeZone: selectedTz });
+    const minDate = new Date(nowInTz).toISOString().split('T')[0];
+    dateInput.min = minDate;
+    dateInput.value = minDate;
+  };
+
+  const updateDefaultTime = () => {
+    if (!timeInput || !tzSelect) return;
+
+    try {
+      const selectedTz = tzSelect.value;
+      const now = new Date();
+      const formatter = new Intl.DateTimeFormat('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+        timeZone: selectedTz
+      });
+      const parts = formatter.formatToParts(now);
+      let hour = parseInt(parts.find(p => p.type === 'hour')?.value ?? '0', 10);
+      hour = (hour + 1) % 24;
+      timeInput.value = `${hour.toString().padStart(2, '0')}:00`;
+    } catch (e) {
+      const now = new Date();
+      now.setHours(now.getHours() + 1);
+      now.setMinutes(0);
+      timeInput.value = now.toTimeString().slice(0, 5);
+    }
+  };
+
+  if (dateInput) {
+    updateMinDate();
+  }
+
+  if (timeInput) {
+    updateDefaultTime();
+  }
+
+  if (tzSelect) {
+    const handleTzChange = () => {
+      updateMinDate();
+      updateDefaultTime();
+    };
+    tzSelect.removeEventListener('change', handleTzChange);
+    tzSelect.addEventListener('change', handleTzChange);
+  }
+}
+
+function attachScheduleModalHandlers() {
+  const modal = document.getElementById('scheduleQueueModal');
+  if (!modal) return;
+
+  const closeBtn = document.getElementById('closeScheduleModal');
+  const cancelBtn = document.getElementById('cancelSchedule');
+  const confirmBtn = document.getElementById('confirmSchedule');
+
+  if (closeBtn) closeBtn.onclick = hideScheduleModal;
+  if (cancelBtn) cancelBtn.onclick = hideScheduleModal;
+  if (confirmBtn) confirmBtn.onclick = confirmScheduleItems;
+
+  modal.onclick = (e) => {
+    if (e.target === modal) hideScheduleModal();
+  };
+}
+
+export function hideScheduleModal() {
+  const modal = document.getElementById('scheduleQueueModal');
+  if (modal) {
+    modal.style.display = 'none';
+    const errorDiv = document.getElementById('scheduleError');
+    if (errorDiv) {
+      errorDiv.classList.add('hidden');
+      errorDiv.textContent = '';
+    }
+  }
+  scheduleState.selectedIds = [];
+  scheduleState.onSchedule = null;
+}
+
+async function confirmScheduleItems() {
+  const user = window.auth?.currentUser;
+  if (!user) return;
+
+  const dateInput = document.getElementById('scheduleDate');
+  const timeInput = document.getElementById('scheduleTime');
+  const timeZoneSelect = document.getElementById('scheduleTimeZone');
+  const retryCheckbox = document.getElementById('scheduleRetryOnFailure');
+  const errorDiv = document.getElementById('scheduleError');
+
+  errorDiv.classList.add('hidden');
+  errorDiv.textContent = '';
+
+  if (!dateInput.value || !timeInput.value) {
+    errorDiv.textContent = 'Date and time are required';
+    errorDiv.classList.remove('hidden');
+    return;
+  }
+
+  const selectedDate = dateInput.value;
+  const selectedTime = timeInput.value;
+  const selectedTimeZone = timeZoneSelect.value;
+
+  const dateTimeStr = `${selectedDate}T${selectedTime}:00`;
+  const scheduledDate = parseDateInTimeZone(dateTimeStr, selectedTimeZone);
+
+  const now = new Date();
+  if (scheduledDate < now) {
+    errorDiv.textContent = 'Scheduled time must be in the future';
+    errorDiv.classList.remove('hidden');
+    return;
+  }
+
+  await saveUserTimeZone(selectedTimeZone);
+
+  const queueSelections = scheduleState.selectedIds;
+
+  try {
+    const scheduledAt = firebase.firestore.Timestamp.fromDate(scheduledDate);
+    const retryOnFailure = retryCheckbox ? retryCheckbox.checked : false;
+
+    for (const docId of queueSelections) {
+      await updateJulesQueueItem(user.uid, docId, {
+        status: 'scheduled',
+        scheduledAt: scheduledAt,
+        scheduledTimeZone: selectedTimeZone,
+        retryOnFailure: retryOnFailure,
+        retryCount: 0,
+        updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+      });
+    }
+
+    const totalScheduled = queueSelections.length;
+
+    const formattedScheduledAt = new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: selectedTimeZone,
+      timeZoneName: 'short'
+    }).format(scheduledDate);
+
+    const itemText = totalScheduled === 1 ? 'item' : 'items';
+    showToast(`Scheduled ${totalScheduled} ${itemText} for ${formattedScheduledAt}`, 'success');
+
+    const callback = scheduleState.onSchedule;
+    hideScheduleModal();
+
+    if (callback) {
+      await callback();
+    }
+  } catch (err) {
+    errorDiv.textContent = `Failed to schedule items: ${err.message}`;
+    errorDiv.classList.remove('hidden');
+  }
+}
+
+function parseDateInTimeZone(dateTimeStr, timeZone) {
+  const parts = dateTimeStr.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})$/);
+  if (!parts) {
+    throw new Error('Invalid date format');
+  }
+
+  const [, year, month, day, hour, minute, second] = parts;
+  const dateInTz = new Date(new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}`).toLocaleString('en-US', { timeZone }));
+  const dateInLocal = new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}`);
+  const offset = dateInLocal - dateInTz;
+
+  return new Date(dateInLocal.getTime() - offset);
+}
+
+function getCommonTimeZones() {
+  return [
+    { value: 'America/New_York', label: 'New York (ET)' },
+    { value: 'America/Chicago', label: 'Chicago (CT)' },
+    { value: 'America/Denver', label: 'Denver (MT)' },
+    { value: 'America/Los_Angeles', label: 'Los Angeles (PT)' },
+    { value: 'America/Anchorage', label: 'Anchorage (AKT)' },
+    { value: 'Pacific/Honolulu', label: 'Honolulu (HT)' },
+    { value: 'America/Mexico_City', label: 'Mexico City (CST)' },
+    { value: 'America/Toronto', label: 'Toronto (ET)' },
+    { value: 'America/Sao_Paulo', label: 'São Paulo (BRT)' },
+    { value: 'America/Buenos_Aires', label: 'Buenos Aires (ART)' },
+    { value: 'Europe/London', label: 'London (GMT/BST)' },
+    { value: 'Europe/Paris', label: 'Paris (CET/CEST)' },
+    { value: 'Europe/Berlin', label: 'Berlin (CET/CEST)' },
+    { value: 'Europe/Moscow', label: 'Moscow (MSK)' },
+    { value: 'Africa/Cairo', label: 'Cairo (EET)' },
+    { value: 'Africa/Johannesburg', label: 'Johannesburg (SAST)' },
+    { value: 'Asia/Dubai', label: 'Dubai (GST)' },
+    { value: 'Asia/Kolkata', label: 'India (IST)' },
+    { value: 'Asia/Singapore', label: 'Singapore (SGT)' },
+    { value: 'Asia/Bangkok', label: 'Bangkok (ICT)' },
+    { value: 'Asia/Shanghai', label: 'Shanghai (CST)' },
+    { value: 'Asia/Tokyo', label: 'Tokyo (JST)' },
+    { value: 'Australia/Sydney', label: 'Sydney (AEDT/AEST)' },
+    { value: 'Pacific/Auckland', label: 'Auckland (NZDT/NZST)' },
+    { value: 'UTC', label: 'UTC' }
+  ];
+}

--- a/src/modules/jules-subtask-modal.js
+++ b/src/modules/jules-subtask-modal.js
@@ -6,7 +6,7 @@
 import { analyzePromptStructure, buildSubtaskSequence, validateSubtasks } from './subtask-manager.js';
 import { showSubtaskErrorModal, openUrlInBackground } from './jules-modal.js';
 import { getLastSelectedSource } from './jules-free-input.js';
-import { addToJulesQueue } from './jules-queue.js';
+import { addToJulesQueue } from './jules-queue-api.js';
 import { callRunJulesFunction } from './jules-api.js';
 import { showToast } from './toast.js';
 import { showConfirm } from './confirm-modal.js';

--- a/src/pages/queue-page.js
+++ b/src/pages/queue-page.js
@@ -4,7 +4,8 @@
  */
 
 import { initMutualExclusivity } from '../utils/checkbox-helpers.js';
-import { attachQueueHandlers, listJulesQueue, renderQueueListDirectly } from '../modules/jules-queue.js';
+import { attachQueueHandlers, renderQueueListDirectly } from '../modules/jules-queue.js';
+import { listJulesQueue } from '../modules/jules-queue-api.js';
 import { loadSubtaskErrorModal } from '../modules/jules-modal.js';
 import { TIMEOUTS } from '../utils/constants.js';
 


### PR DESCRIPTION
Split the monolithic `jules-queue.js` into four focused modules:
- `jules-queue-api.js`: Handles Firestore CRUD operations.
- `jules-queue-render.js`: Handles DOM rendering of queue items.
- `jules-queue-edit.js`: Manages the Edit Queue Item modal logic.
- `jules-queue-schedule.js`: Manages the Schedule Queue modal logic.

The original `jules-queue.js` is retained as a coordinator module to orchestrate these submodules and maintain backward compatibility. Updated imports in `queue-page.js`, `jules-free-input.js`, `jules-subtask-modal.js`, and `jules-modal.js` to reference the new API module where appropriate.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/892d1c50-442f-413a-9ccc-f81ad3ecb1e4" />

---
https://jules.google.com/session/17196148267166211000