### PR TITLE
Refactor Firestore operations to use new abstraction layer with caching and retry logic.

### DIFF
--- a/src/modules/jules-keys.js
+++ b/src/modules/jules-keys.js
@@ -1,13 +1,12 @@
 // ===== Jules Key Management Module =====
 // Handles encryption, storage, and retrieval of Jules API keys
 
+import { getDoc, setDoc, deleteDoc } from '../utils/firestore-helpers.js';
+
 export async function checkJulesKey(uid) {
   try {
-    if (!window.db) {
-      return false;
-    }
-    const doc = await window.db.collection('julesKeys').doc(uid).get();
-    return doc.exists;
+    const doc = await getDoc('julesKeys', uid);
+    return !!doc;
   } catch (error) {
     return false;
   }
@@ -15,8 +14,7 @@ export async function checkJulesKey(uid) {
 
 export async function deleteStoredJulesKey(uid) {
   try {
-    if (!window.db) return false;
-    await window.db.collection('julesKeys').doc(uid).delete();
+    await deleteDoc('julesKeys', uid);
     return true;
   } catch (error) {
     return false;
@@ -35,8 +33,7 @@ export async function encryptAndStoreKey(plaintext, uid) {
     const ciphertext = await window.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintextData);
     const encrypted = btoa(String.fromCharCode(...new Uint8Array(ciphertext)));
 
-    if (!window.db) throw new Error('Firestore not initialized');
-    await window.db.collection('julesKeys').doc(uid).set({
+    await setDoc('julesKeys', uid, {
       key: encrypted,
       storedAt: firebase.firestore.FieldValue.serverTimestamp()
     });

--- a/src/utils/firestore-helpers.js
+++ b/src/utils/firestore-helpers.js
@@ -1,0 +1,222 @@
+import { getCache, setCache, clearCache } from './session-cache.js';
+import { RETRY_CONFIG } from './constants.js';
+
+const DB_NOT_INITIALIZED = 'Firestore not initialized';
+
+function getDb() {
+  if (typeof window !== 'undefined' && window.db) {
+    return window.db;
+  }
+  if (typeof firebase !== 'undefined' && firebase.firestore) {
+      return firebase.firestore();
+  }
+  throw new Error(DB_NOT_INITIALIZED);
+}
+
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+async function retryOperation(operation, retries = RETRY_CONFIG.maxRetries) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (i === retries - 1) throw err;
+      const delay = RETRY_CONFIG.baseDelay * Math.pow(2, i);
+      await sleep(delay);
+    }
+  }
+}
+
+/**
+ * Get a single document with caching
+ * @param {string} collectionPath - Collection path (e.g. 'users' or 'users/uid/settings')
+ * @param {string} docId - Document ID
+ * @param {string} [cacheKey] - Session storage cache key. If provided, checks cache first.
+ * @returns {Promise<Object|null>} Document data with id or null
+ */
+export async function getDoc(collectionPath, docId, cacheKey = null) {
+  if (cacheKey) {
+    const cached = getCache(cacheKey);
+    if (cached) return cached;
+  }
+
+  return retryOperation(async () => {
+    const db = getDb();
+    const snapshot = await db.collection(collectionPath).doc(docId).get();
+
+    if (snapshot.exists) {
+      const data = { id: snapshot.id, ...snapshot.data() };
+      if (cacheKey) {
+        setCache(cacheKey, data);
+      }
+      return data;
+    }
+    return null;
+  });
+}
+
+/**
+ * Query a collection with caching
+ * @param {string} collectionPath - Collection path
+ * @param {Object} options - Query options
+ * @param {Array} [options.where] - Array of filters: [['field', 'op', 'value'], ...]
+ * @param {Array|string} [options.orderBy] - Order by field or ['field', 'desc']
+ * @param {number} [options.limit] - Limit results
+ * @param {string} [cacheKey] - Session storage cache key
+ * @returns {Promise<Array>} Array of document objects
+ */
+export async function queryCollection(collectionPath, options = {}, cacheKey = null) {
+  if (cacheKey) {
+    const cached = getCache(cacheKey);
+    if (cached) return cached;
+  }
+
+  return retryOperation(async () => {
+    const db = getDb();
+    let query = db.collection(collectionPath);
+
+    if (options.where) {
+      options.where.forEach(w => {
+        if (Array.isArray(w) && w.length === 3) {
+          query = query.where(w[0], w[1], w[2]);
+        }
+      });
+    }
+
+    if (options.orderBy) {
+      if (Array.isArray(options.orderBy)) {
+         if (options.orderBy.length === 2) {
+             query = query.orderBy(options.orderBy[0], options.orderBy[1]);
+         } else {
+             query = query.orderBy(options.orderBy[0]);
+         }
+      } else {
+        query = query.orderBy(options.orderBy);
+      }
+    }
+
+    if (options.limit) {
+        query = query.limit(options.limit);
+    }
+
+    const snapshot = await query.get();
+    const results = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+
+    if (cacheKey) {
+      setCache(cacheKey, results);
+    }
+    return results;
+  });
+}
+
+/**
+ * Set (create or overwrite) a document
+ * @param {string} collectionPath
+ * @param {string} docId - If null, will use add() (auto-id)
+ * @param {Object} data
+ * @param {Object} options
+ * @param {boolean} [options.merge] - Merge data instead of overwrite
+ * @param {string} [options.cacheKey] - Update this cache key (optimistic)
+ * @param {string} [options.invalidateCacheKey] - Clear this cache key
+ * @param {Object} [options.optimisticData] - Data to put in cache
+ * @returns {Promise<string|void>} docId
+ */
+export async function setDoc(collectionPath, docId, data, options = {}) {
+    if (options.cacheKey) {
+        setCache(options.cacheKey, options.optimisticData || data);
+    }
+    if (options.invalidateCacheKey) {
+        clearCache(options.invalidateCacheKey);
+    }
+
+    return retryOperation(async () => {
+        const db = getDb();
+        if (docId) {
+             await db.collection(collectionPath).doc(docId).set(data, { merge: options.merge });
+             return docId;
+        } else {
+             const ref = await db.collection(collectionPath).add(data);
+             return ref.id;
+        }
+    });
+}
+
+/**
+ * Add a document (wrapper for setDoc with null id)
+ */
+export async function addDoc(collectionPath, data, options = {}) {
+    return setDoc(collectionPath, null, data, options);
+}
+
+/**
+ * Update a document
+ * @param {string} collectionPath
+ * @param {string} docId
+ * @param {Object} data
+ * @param {Object} options
+ * @param {string} [options.cacheKey] - Update this cache key
+ * @param {string} [options.invalidateCacheKey] - Clear this cache key
+ * @param {Object} [options.optimisticData] - Data to put in cache
+ */
+export async function updateDoc(collectionPath, docId, data, options = {}) {
+    if (options.cacheKey && options.optimisticData) {
+        setCache(options.cacheKey, options.optimisticData);
+    }
+    if (options.invalidateCacheKey) {
+        clearCache(options.invalidateCacheKey);
+    }
+
+    return retryOperation(async () => {
+        const db = getDb();
+        await db.collection(collectionPath).doc(docId).update(data);
+        return true;
+    });
+}
+
+/**
+ * Delete a document
+ * @param {string} collectionPath
+ * @param {string} docId
+ * @param {Object} options
+ * @param {string} [options.invalidateCacheKey] - Clear this cache key
+ */
+export async function deleteDoc(collectionPath, docId, options = {}) {
+    if (options.invalidateCacheKey) {
+        clearCache(options.invalidateCacheKey);
+    }
+
+    return retryOperation(async () => {
+        const db = getDb();
+        await db.collection(collectionPath).doc(docId).delete();
+        return true;
+    });
+}
+
+/**
+ * Run a batch of operations
+ * @param {Array<{type: 'set'|'update'|'delete', collection: string, docId: string, data?: Object, options?: Object}>} operations
+ * @param {string} [cacheKeyToInvalidate]
+ */
+export async function runBatch(operations, cacheKeyToInvalidate = null) {
+    if (cacheKeyToInvalidate) {
+        clearCache(cacheKeyToInvalidate);
+    }
+
+    return retryOperation(async () => {
+        const db = getDb();
+        const batch = db.batch();
+
+        operations.forEach(op => {
+            const ref = db.collection(op.collection).doc(op.docId);
+            if (op.type === 'set') {
+                batch.set(ref, op.data, op.options);
+            } else if (op.type === 'update') {
+                batch.update(ref, op.data);
+            } else if (op.type === 'delete') {
+                batch.delete(ref);
+            }
+        });
+
+        await batch.commit();
+    });
+}

--- a/tests/test-firestore-helpers.mjs
+++ b/tests/test-firestore-helpers.mjs
@@ -1,0 +1,140 @@
+// Polyfill globals for Node environment
+global.sessionStorage = {
+  store: {},
+  getItem: function(key) { return this.store[key] || null; },
+  setItem: function(key, value) { this.store[key] = value; },
+  removeItem: function(key) { delete this.store[key]; },
+  clear: function() { this.store = {}; }
+};
+
+global.window = {
+    db: null
+};
+
+// Mock Firestore
+const mockDocRef = {
+  get: async () => ({ exists: false, id: 'test', data: () => ({}) }),
+  set: async () => {},
+  update: async () => {},
+  delete: async () => {}
+};
+
+const mockCollectionRef = {
+  doc: () => mockDocRef,
+  add: async () => ({ id: 'new-id' }),
+  where: function() { return this; },
+  orderBy: function() { return this; },
+  limit: function() { return this; },
+  get: async () => ({ docs: [] })
+};
+
+const mockBatch = {
+    set: () => {},
+    update: () => {},
+    delete: () => {},
+    commit: async () => {}
+};
+
+global.window.db = {
+  collection: (path) => mockCollectionRef,
+  batch: () => mockBatch
+};
+
+// Import modules
+import * as helpers from '../src/utils/firestore-helpers.js';
+import * as assert from 'assert';
+
+async function runTests() {
+  console.log('Running Firestore Helpers Tests...');
+
+  // Test 1: getDoc with cache miss then hit
+  console.log('Test 1: getDoc caching');
+  global.sessionStorage.clear();
+
+  // Mock return value
+  mockDocRef.get = async () => ({
+      exists: true,
+      id: 'doc1',
+      data: () => ({ foo: 'bar' })
+  });
+
+  const result1 = await helpers.getDoc('col', 'doc1', 'cache_key_1');
+  assert.strictEqual(result1.foo, 'bar');
+
+  // Verify cache set
+  const cached = JSON.parse(global.sessionStorage.getItem('cache_key_1'));
+  assert.strictEqual(cached.data.foo, 'bar');
+
+  // Modify cache to prove getDoc uses it
+  global.sessionStorage.setItem('cache_key_1', JSON.stringify({ data: { foo: 'cached' }, timestamp: Date.now() }));
+  const result2 = await helpers.getDoc('col', 'doc1', 'cache_key_1');
+  assert.strictEqual(result2.foo, 'cached');
+  console.log('PASS');
+
+  // Test 2: queryCollection
+  console.log('Test 2: queryCollection caching');
+  global.sessionStorage.clear();
+  mockCollectionRef.get = async () => ({
+      docs: [{ id: 'd1', data: () => ({ val: 1 }) }]
+  });
+
+  const qResult1 = await helpers.queryCollection('col', {}, 'q_key');
+  assert.strictEqual(qResult1.length, 1);
+  assert.strictEqual(qResult1[0].val, 1);
+
+  // Verify cache
+  const qCached = JSON.parse(global.sessionStorage.getItem('q_key'));
+  assert.strictEqual(qCached.data[0].val, 1);
+
+  // Modify cache
+  global.sessionStorage.setItem('q_key', JSON.stringify({ data: [{ id: 'd1', val: 999 }], timestamp: Date.now() }));
+  const qResult2 = await helpers.queryCollection('col', {}, 'q_key');
+  assert.strictEqual(qResult2[0].val, 999);
+  console.log('PASS');
+
+  // Test 3: setDoc optimistic update
+  console.log('Test 3: setDoc optimistic update');
+  global.sessionStorage.clear();
+
+  await helpers.setDoc('col', 'doc2', { val: 'new' }, { cacheKey: 'doc2_key' });
+
+  const setCached = JSON.parse(global.sessionStorage.getItem('doc2_key'));
+  assert.strictEqual(setCached.data.val, 'new');
+  console.log('PASS');
+
+  // Test 4: retry logic (mock failure)
+  console.log('Test 4: Retry logic');
+  let attempts = 0;
+  mockDocRef.get = async () => {
+      attempts++;
+      if (attempts < 2) throw new Error('fail');
+      return { exists: true, id: 'retry', data: () => ({ success: true }) };
+  };
+
+  const retryResult = await helpers.getDoc('col', 'retry');
+  assert.strictEqual(retryResult.success, true);
+  assert.strictEqual(attempts, 2);
+  console.log('PASS');
+
+  // Test 5: runBatch
+  console.log('Test 5: runBatch');
+  global.sessionStorage.clear();
+  // Mock batch commit spy
+  let batchCommited = false;
+  mockBatch.commit = async () => { batchCommited = true; };
+
+  await helpers.runBatch([
+    { type: 'set', collection: 'col', docId: 'd1', data: {a:1} },
+    { type: 'update', collection: 'col', docId: 'd2', data: {b:2} }
+  ], 'batch_invalidate_key');
+
+  assert.strictEqual(batchCommited, true);
+  console.log('PASS');
+
+  console.log('All tests passed!');
+}
+
+runTests().catch(e => {
+    console.error('Test failed:', e);
+    process.exit(1);
+});


### PR DESCRIPTION
- Created `src/utils/firestore-helpers.js` with `getDoc`, `queryCollection`, `setDoc`, `addDoc`, `updateDoc`, `deleteDoc`, and `runBatch`.
- Implemented automatic caching via `session-cache.js` integration.
- Implemented retry logic with exponential backoff.
- Refactored `src/modules/jules-keys.js` to use helper functions.
- Refactored `src/modules/jules-queue.js` to use helper functions and `runBatch` for atomic updates.
- Added unit tests in `tests/test-firestore-helpers.mjs`.

---
https://jules.google.com/session/14650749528563248641