### PR TITLE
Add missing ARIA attributes and keyboard support for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
       </div>
       <div class="search-wrapper">
         <input id="search" placeholder="Search prompts..." />
-        <button id="searchClear" class="search-clear hidden" title="Clear search"><span class="icon" aria-hidden="true">close</span></button>
+        <button id="searchClear" class="search-clear hidden" title="Clear search" aria-label="Clear search"><span class="icon" aria-hidden="true">close</span></button>
       </div>
       <button class="btn" id="freeInputBtn" title="Send a custom prompt to Jules"><span class="icon icon-inline" aria-hidden="true">edit_note</span> Free Input</button>
       <div id="list"></div>
@@ -147,7 +147,7 @@
   </div>
 
   <!-- Jules API Key Modal -->
-  <div id="julesKeyModal" class="modal">
+  <div id="julesKeyModal" class="modal" role="dialog" aria-modal="true">
     <div class="modal-content">
       <h2>Save Jules API Key</h2>
       <p>Enter your Jules API key. This will be encrypted and stored securely.</p>
@@ -160,7 +160,7 @@
   </div>
 
   <!-- Jules Environment Modal -->
-  <div id="julesEnvModal" class="modal">
+  <div id="julesEnvModal" class="modal" role="dialog" aria-modal="true">
     <div class="modal-content">
       <h2>Choose Repository</h2>
       <p>Select a connected repository to open in Jules.</p>
@@ -209,7 +209,7 @@
   </div>
 
   <!-- Subtask Split Modal -->
-  <div id="subtaskSplitModal" class="modal">
+  <div id="subtaskSplitModal" class="modal" role="dialog" aria-modal="true">
     <div class="modal-content modal-lg">
       <h2>Break into Subtasks</h2>
       
@@ -238,7 +238,7 @@
   </div>
 
   <!-- Subtask Preview Modal -->
-  <div id="subtaskPreviewModal" class="modal">
+  <div id="subtaskPreviewModal" class="modal" role="dialog" aria-modal="true">
     <div class="modal-content modal-xl">
       <h2 id="subtaskPreviewTitle">Subtask Preview</h2>
       <div id="subtaskPreviewContent" class="scroll-box"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -237,6 +238,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1066,6 +1068,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2036,6 +2039,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -2737,6 +2741,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2820,6 +2825,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/partials/subtask-error-modal.html
+++ b/partials/subtask-error-modal.html
@@ -1,5 +1,5 @@
 <!-- Subtask Error Modal -->
-<div id="subtaskErrorModal" class="modal">
+<div id="subtaskErrorModal" class="modal" role="dialog" aria-modal="true">
   <div class="modal-content modal-lg">
     <div class="modal-header">
       <h3 id="errorModalTitle" class="modal-title"><span class="icon icon-inline" aria-hidden="true">warning</span> Task Failed</h3>

--- a/src/modules/confirm-modal.js
+++ b/src/modules/confirm-modal.js
@@ -13,6 +13,12 @@ function createConfirmModal() {
   modal.id = 'confirmModal';
   modal.style.zIndex = '10000';
 
+  // Accessibility attributes
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+  modal.setAttribute('aria-labelledby', 'confirmModalTitle');
+  modal.setAttribute('aria-describedby', 'confirmModalMessage');
+
   const modalContent = createElement('div', 'modal-content');
   modalContent.style.maxWidth = '480px';
 

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -61,6 +61,10 @@ export function initDropdown(btn, menu, container = null) {
   const dropdownContainer = container || menu.parentNode;
   const dropdown = { btn, menu, container: dropdownContainer };
 
+  // Add ARIA attributes
+  btn.setAttribute('aria-haspopup', 'true');
+  btn.setAttribute('aria-expanded', 'false');
+
   btn.addEventListener('click', (e) => {
     e.stopPropagation();
     toggleDropdown(dropdown);

--- a/src/modules/prompt-list.js
+++ b/src/modules/prompt-list.js
@@ -65,6 +65,7 @@ export function initPromptList() {
   }
   folderSubmenu.init();
   listEl.addEventListener('click', handleListClick);
+  listEl.addEventListener('keydown', handleListKeydown);
 }
 
 export function destroyPromptList() {
@@ -158,6 +159,18 @@ export async function toggleDirectory(path, expand) {
     persistExpandedState();
   }
   await renderList(files, currentOwner, currentRepo, currentBranch);
+}
+
+function handleListKeydown(event) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    const target = event.target;
+    // Handle specific role="button" elements (like icons)
+    if (target.getAttribute('role') === 'button') {
+      event.preventDefault();
+      event.stopPropagation();
+      target.click();
+    }
+  }
 }
 
 function handleListClick(event) {
@@ -287,6 +300,8 @@ function renderTree(node, container, forcedExpanded, owner, repo, branch) {
       toggle.type = 'button';
       const isForced = forcedExpanded.has(entry.path);
       const isExpanded = isForced || expandedState.has(entry.path);
+      toggle.setAttribute('aria-expanded', String(!!isExpanded));
+      toggle.setAttribute('aria-label', `Toggle ${entry.name}`);
       toggle.innerHTML = isExpanded 
         ? '<span class="icon" aria-hidden="true">expand_more</span>'
         : '<span class="icon" aria-hidden="true">chevron_right</span>';
@@ -303,7 +318,9 @@ function renderTree(node, container, forcedExpanded, owner, repo, branch) {
       const ghIcon = document.createElement('span');
       ghIcon.className = 'github-folder-icon icon icon-inline';
       ghIcon.textContent = 'folder';
-      ghIcon.setAttribute('aria-hidden', 'true');
+      ghIcon.setAttribute('role', 'button');
+      ghIcon.setAttribute('tabindex', '0');
+      ghIcon.setAttribute('aria-label', 'Open directory on GitHub');
       ghIcon.title = 'Open directory on GitHub';
       ghIcon.dataset.action = 'open-github';
       ghIcon.dataset.path = entry.path;
@@ -311,7 +328,9 @@ function renderTree(node, container, forcedExpanded, owner, repo, branch) {
       const addIcon = document.createElement('span');
       addIcon.className = 'add-file-icon icon icon-inline';
       addIcon.textContent = 'add';
-      addIcon.setAttribute('aria-hidden', 'true');
+      addIcon.setAttribute('role', 'button');
+      addIcon.setAttribute('tabindex', '0');
+      addIcon.setAttribute('aria-label', 'Create new file in this directory');
       addIcon.title = 'Create new file in this directory';
       addIcon.dataset.action = 'show-submenu';
       addIcon.dataset.path = entry.path;

--- a/src/modules/repo-branch-selector.js
+++ b/src/modules/repo-branch-selector.js
@@ -20,6 +20,7 @@ function setupClickOutsideClose(targetBtn, targetMenu) {
   const closeDropdown = (e) => {
     if (!targetBtn.contains(e.target) && !targetMenu.contains(e.target)) {
       targetMenu.style.display = 'none';
+      targetBtn.setAttribute('aria-expanded', 'false');
     }
   };
   
@@ -72,6 +73,8 @@ export class RepoSelector {
     }
 
     this.dropdownBtn.disabled = false;
+    this.dropdownBtn.setAttribute('aria-haspopup', 'true');
+    this.dropdownBtn.setAttribute('aria-expanded', 'false');
 
     const { DEFAULT_FAVORITE_REPOS } = await import('../utils/constants.js');
     
@@ -144,9 +147,12 @@ export class RepoSelector {
       e.stopPropagation();
       if (this.dropdownMenu.style.display === 'block') {
         this.dropdownMenu.style.display = 'none';
+        this.dropdownBtn.setAttribute('aria-expanded', 'false');
         return;
       }
       
+      this.dropdownBtn.setAttribute('aria-expanded', 'true');
+
       // Position dropdown menu if it's fixed (e.g., in modals)
       const computedStyle = window.getComputedStyle(this.dropdownMenu);
       if (computedStyle.position === 'fixed') {
@@ -320,6 +326,9 @@ export class RepoSelector {
       ? '<span class="icon icon-inline" aria-hidden="true">star</span>'
       : '<span class="icon icon-inline" aria-hidden="true">star_border</span>';
     star.className = 'star-icon';
+    star.setAttribute('role', 'button');
+    star.setAttribute('tabindex', '0');
+    star.setAttribute('aria-label', isFavorite ? 'Remove from favorites' : 'Add to favorites');
     star.dataset.favorited = isFavorite.toString();
     
     star.onclick = async (e) => {
@@ -332,6 +341,14 @@ export class RepoSelector {
         const defaultBranch = extractDefaultBranch(this.allSources.find(s => (s.name || s.id) === id));
         await this.addFavorite(id, name, defaultBranch);
         item.remove();
+      }
+    };
+
+    star.onkeydown = (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        star.click();
       }
     };
     
@@ -508,6 +525,8 @@ export class BranchSelector {
     
     this.dropdownText.textContent = defaultBranch || 'Select a branch...';
     this.dropdownBtn.disabled = false;
+    this.dropdownBtn.setAttribute('aria-haspopup', 'true');
+    this.dropdownBtn.setAttribute('aria-expanded', 'false');
     this.dropdownBtn.style.opacity = '1';
     this.dropdownBtn.style.cursor = 'pointer';
     
@@ -522,9 +541,12 @@ export class BranchSelector {
       e.stopPropagation();
       if (this.dropdownMenu.style.display === 'block') {
         this.dropdownMenu.style.display = 'none';
+        this.dropdownBtn.setAttribute('aria-expanded', 'false');
         return;
       }
       
+      this.dropdownBtn.setAttribute('aria-expanded', 'true');
+
       // Position dropdown menu if it's fixed (e.g., in modals)
       const computedStyle = window.getComputedStyle(this.dropdownMenu);
       if (computedStyle.position === 'fixed') {

--- a/src/tests/modules/repo-branch-selector.test.js
+++ b/src/tests/modules/repo-branch-selector.test.js
@@ -69,8 +69,10 @@ global.document = {
       left: '',
       width: ''
     },
+    dataset: {},
     onclick: null,
     appendChild: vi.fn(),
+    setAttribute: vi.fn(),
     contains: vi.fn(() => false),
     getBoundingClientRect: vi.fn(() => ({
       top: 100,
@@ -106,6 +108,7 @@ const createMockElement = (id = '') => ({
     width: 200
   })),
   appendChild: vi.fn(),
+  setAttribute: vi.fn(),
   innerHTML: '',
   _closeDropdownHandler: null
 });


### PR DESCRIPTION
- Audit and update dropdowns with `aria-haspopup` and `aria-expanded`.
- Add `role="dialog"` and `aria-modal="true"` to modals.
- Update tree navigation to use `aria-expanded` and add labels to icon buttons.
- Add `role="button"`, `tabindex="0"`, and `aria-label` to icon-only buttons.
- Implement keyboard support (Enter/Space) for non-semantic button elements.
- Verify changes with tests and Playwright script.

---
https://jules.google.com/session/17873026277174923684