### PR TITLE
Refactor inline styles to semantic CSS classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -237,6 +238,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1066,6 +1068,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2036,6 +2039,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -2737,6 +2741,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2820,6 +2825,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/src/modules/repo-branch-selector.js
+++ b/src/modules/repo-branch-selector.js
@@ -166,7 +166,7 @@ export class RepoSelector {
     this.dropdownMenu.innerHTML = '';
     
     const loadingIndicator = document.createElement('div');
-    loadingIndicator.style.cssText = 'padding:12px; text-align:center; color:var(--muted); font-size:13px;';
+    loadingIndicator.className = 'dropdown-loading';
     loadingIndicator.textContent = 'Loading...';
     this.dropdownMenu.appendChild(loadingIndicator);
     this.dropdownMenu.style.display = 'block';
@@ -233,14 +233,14 @@ export class RepoSelector {
     showMoreBtn.onclick = async () => {
       if (!this.allReposLoaded) {
         showMoreBtn.textContent = 'Loading...';
-        showMoreBtn.style.pointerEvents = 'none';
+        showMoreBtn.classList.add('pointer-events-none');
         
         try {
           await this.loadAllRepos();
           this.allReposLoaded = true;
         } catch (error) {
           showMoreBtn.textContent = 'Failed to load - click to retry';
-          showMoreBtn.style.pointerEvents = 'auto';
+          showMoreBtn.classList.remove('pointer-events-none');
           return;
         }
       }
@@ -501,15 +501,13 @@ export class BranchSelector {
     if (!sourceId) {
       this.dropdownText.textContent = 'Select repository first';
       this.dropdownBtn.disabled = true;
-      this.dropdownBtn.style.opacity = '0.5';
-      this.dropdownBtn.style.cursor = 'not-allowed';
+      this.dropdownBtn.classList.add('opacity-half', 'cursor-not-allowed');
       return;
     }
     
     this.dropdownText.textContent = defaultBranch || 'Select a branch...';
     this.dropdownBtn.disabled = false;
-    this.dropdownBtn.style.opacity = '1';
-    this.dropdownBtn.style.cursor = 'pointer';
+    this.dropdownBtn.classList.remove('opacity-half', 'cursor-not-allowed');
     
     // Save to storage
     this.saveToStorage();
@@ -556,8 +554,7 @@ export class BranchSelector {
     
     // Hide star for current item
     const star = document.createElement('span');
-    star.className = 'star-icon';
-    star.style.visibility = 'hidden';
+    star.className = 'star-icon visibility-hidden';
     
     const nameSpan = document.createElement('span');
     nameSpan.className = 'item-name';
@@ -575,7 +572,7 @@ export class BranchSelector {
       if (this.allBranchesLoaded) return;
       
       showMoreBtn.textContent = 'Loading...';
-      showMoreBtn.style.pointerEvents = 'none';
+      showMoreBtn.classList.add('pointer-events-none');
       
       try {
         const pathParts = this.sourceId.split('/');
@@ -587,8 +584,8 @@ export class BranchSelector {
 
         if (!allBranches || allBranches.length === 0) {
           showMoreBtn.textContent = allBranches === null ? 'GitHub API rate limited - try later' : 'No branches found';
-          showMoreBtn.style.color = 'var(--muted)';
-          showMoreBtn.style.pointerEvents = 'auto';
+          showMoreBtn.classList.add('status-muted');
+          showMoreBtn.classList.remove('pointer-events-none');
           return;
         }
 
@@ -603,8 +600,7 @@ export class BranchSelector {
           
           // Hide star for branches (not using favorites here)
           const star = document.createElement('span');
-          star.className = 'star-icon';
-          star.style.visibility = 'hidden';
+          star.className = 'star-icon visibility-hidden';
           
           const nameSpan = document.createElement('span');
           nameSpan.className = 'item-name';
@@ -622,8 +618,8 @@ export class BranchSelector {
       } catch (error) {
         console.error('Failed to load branches:', error);
         showMoreBtn.textContent = 'Failed to load - click to retry';
-        showMoreBtn.style.color = 'var(--muted)';
-        showMoreBtn.style.pointerEvents = 'auto';
+        showMoreBtn.classList.add('status-muted');
+        showMoreBtn.classList.remove('pointer-events-none');
       }
     };
     

--- a/src/modules/status-renderer.js
+++ b/src/modules/status-renderer.js
@@ -16,12 +16,12 @@ export const STATUS_TYPES = {
 };
 
 const STATUS_CONFIG = {
-  [STATUS_TYPES.SAVED]: { icon: 'check_circle', colorClass: 'color-accent' },
-  [STATUS_TYPES.NOT_SAVED]: { icon: 'cancel', colorClass: 'color-muted' },
-  [STATUS_TYPES.LOADING]: { icon: 'hourglass_top', colorClass: '' },
-  [STATUS_TYPES.ERROR]: { icon: 'error', colorClass: 'color-error' },
-  [STATUS_TYPES.SUCCESS]: { icon: 'check_circle', colorClass: 'color-success' },
-  [STATUS_TYPES.DELETING]: { icon: 'hourglass_top', colorClass: '' },
+  [STATUS_TYPES.SAVED]: { icon: 'check_circle', colorClass: 'status-saved' },
+  [STATUS_TYPES.NOT_SAVED]: { icon: 'cancel', colorClass: 'status-not-saved' },
+  [STATUS_TYPES.LOADING]: { icon: 'hourglass_top', colorClass: 'status-loading' },
+  [STATUS_TYPES.ERROR]: { icon: 'error', colorClass: 'status-error' },
+  [STATUS_TYPES.SUCCESS]: { icon: 'check_circle', colorClass: 'status-success' },
+  [STATUS_TYPES.DELETING]: { icon: 'hourglass_top', colorClass: 'status-loading' },
   [STATUS_TYPES.RESET]: { icon: 'refresh', colorClass: '' }
 };
 
@@ -39,7 +39,10 @@ export function renderStatus(container, type, labelOverride = null) {
   const config = STATUS_CONFIG[type] || { icon: 'info', colorClass: '' };
 
   // Remove existing color classes
-  container.classList.remove('color-accent', 'color-muted', 'color-error', 'color-success');
+  container.classList.remove(
+    'color-accent', 'color-muted', 'color-error', 'color-success',
+    'status-saved', 'status-not-saved', 'status-loading', 'status-error', 'status-success', 'status-outdated'
+  );
 
   // Apply new color class if specified
   if (config.colorClass) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,6 +24,7 @@
 @import url('./styles/components/footer.css');
 @import url('./styles/components/split-modal.css');
 @import url('./styles/components/status-bar.css');
+@import url('./styles/components/status.css');
 @import url('./styles/components/tags.css');
 @import url('./styles/components/jules-profile.css');
 @import url('./styles/components/update-banner.css');

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -191,7 +191,7 @@ button.mobile-nav-item { border: none; background: transparent; cursor: pointer;
 
 #appVersion.version-badge--new {
   font-weight: bold;
-  color: #ffe066;
+  color: var(--warn);
 }
 
 .site-title { font-size:16px; font-weight:900; letter-spacing:0.4px; line-height:1.2; }

--- a/src/styles/components/status.css
+++ b/src/styles/components/status.css
@@ -1,0 +1,56 @@
+/* Semantic Status Indicators */
+.status-saved {
+  color: var(--accent);
+}
+
+.status-not-saved {
+  color: var(--muted);
+}
+
+.status-outdated {
+  color: var(--warn);
+}
+
+.status-loading {
+  color: var(--muted);
+}
+
+.status-error {
+  color: var(--error);
+}
+
+.status-success {
+  color: var(--success);
+}
+
+.status-muted {
+  color: var(--muted);
+}
+
+.status-action {
+  color: var(--accent);
+}
+
+/* Helper classes for dropdowns and interactive elements */
+.dropdown-loading {
+  padding: 12px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.opacity-half {
+  opacity: 0.5;
+}
+
+.cursor-not-allowed {
+  cursor: not-allowed;
+}
+
+.pointer-events-none {
+  pointer-events: none;
+}
+
+.visibility-hidden {
+  visibility: hidden;
+}

--- a/src/tests/modules/repo-branch-selector.test.js
+++ b/src/tests/modules/repo-branch-selector.test.js
@@ -52,6 +52,13 @@ global.document = {
     tagName: tag.toUpperCase(),
     className: '',
     textContent: '',
+    dataset: {},
+    classList: {
+      add: vi.fn(),
+      remove: vi.fn(),
+      contains: vi.fn(),
+      toggle: vi.fn()
+    },
     style: {
       cssText: '',
       display: '',
@@ -89,6 +96,12 @@ const createMockElement = (id = '') => ({
   textContent: '',
   disabled: false,
   onclick: null,
+  classList: {
+    add: vi.fn(),
+    remove: vi.fn(),
+    contains: vi.fn(),
+    toggle: vi.fn()
+  },
   style: {
     display: '',
     opacity: '',
@@ -602,8 +615,7 @@ describe('repo-branch-selector', () => {
         branchSelector.initialize('github.com/test/repo', 'main');
         
         expect(mockBtn.disabled).toBe(false);
-        expect(mockBtn.style.opacity).toBe('1');
-        expect(mockBtn.style.cursor).toBe('pointer');
+        expect(mockBtn.classList.remove).toHaveBeenCalledWith('opacity-half', 'cursor-not-allowed');
       });
 
       it('should disable button if no sourceId', () => {
@@ -611,8 +623,7 @@ describe('repo-branch-selector', () => {
         
         expect(mockBtn.disabled).toBe(true);
         expect(mockText.textContent).toBe('Select repository first');
-        expect(mockBtn.style.opacity).toBe('0.5');
-        expect(mockBtn.style.cursor).toBe('not-allowed');
+        expect(mockBtn.classList.add).toHaveBeenCalledWith('opacity-half', 'cursor-not-allowed');
       });
 
       it('should restore from storage if no sourceId provided', () => {

--- a/src/tests/modules/status-renderer.test.js
+++ b/src/tests/modules/status-renderer.test.js
@@ -112,7 +112,13 @@ describe('status-renderer', () => {
         'color-accent',
         'color-muted',
         'color-error',
-        'color-success'
+        'color-success',
+        'status-saved',
+        'status-not-saved',
+        'status-loading',
+        'status-error',
+        'status-success',
+        'status-outdated'
       );
     });
 
@@ -125,10 +131,10 @@ describe('status-renderer', () => {
         expect(createIcon).toHaveBeenCalledWith('check_circle', ['icon-inline']);
       });
 
-      it('should add color-accent class', () => {
+      it('should add status-saved class', () => {
         renderStatus(container, STATUS_TYPES.SAVED);
         
-        expect(container.classList.add).toHaveBeenCalledWith('color-accent');
+        expect(container.classList.add).toHaveBeenCalledWith('status-saved');
       });
 
       it('should append icon to container', () => {
@@ -161,10 +167,10 @@ describe('status-renderer', () => {
         expect(createIcon).toHaveBeenCalledWith('cancel', ['icon-inline']);
       });
 
-      it('should add color-muted class', () => {
+      it('should add status-not-saved class', () => {
         renderStatus(container, STATUS_TYPES.NOT_SAVED);
         
-        expect(container.classList.add).toHaveBeenCalledWith('color-muted');
+        expect(container.classList.add).toHaveBeenCalledWith('status-not-saved');
       });
     });
 
@@ -177,11 +183,10 @@ describe('status-renderer', () => {
         expect(createIcon).toHaveBeenCalledWith('hourglass_top', ['icon-inline']);
       });
 
-      it('should not add any color class', () => {
+      it('should add status-loading class', () => {
         renderStatus(container, STATUS_TYPES.LOADING);
         
-        // Should only remove classes, not add any
-        expect(container.classList.add).not.toHaveBeenCalled();
+        expect(container.classList.add).toHaveBeenCalledWith('status-loading');
       });
 
       it('should display loading message if provided', () => {
@@ -200,10 +205,10 @@ describe('status-renderer', () => {
         expect(createIcon).toHaveBeenCalledWith('error', ['icon-inline']);
       });
 
-      it('should add color-error class', () => {
+      it('should add status-error class', () => {
         renderStatus(container, STATUS_TYPES.ERROR);
         
-        expect(container.classList.add).toHaveBeenCalledWith('color-error');
+        expect(container.classList.add).toHaveBeenCalledWith('status-error');
       });
 
       it('should display error message if provided', () => {
@@ -222,10 +227,10 @@ describe('status-renderer', () => {
         expect(createIcon).toHaveBeenCalledWith('check_circle', ['icon-inline']);
       });
 
-      it('should add color-success class', () => {
+      it('should add status-success class', () => {
         renderStatus(container, STATUS_TYPES.SUCCESS);
         
-        expect(container.classList.add).toHaveBeenCalledWith('color-success');
+        expect(container.classList.add).toHaveBeenCalledWith('status-success');
       });
     });
 
@@ -238,10 +243,10 @@ describe('status-renderer', () => {
         expect(createIcon).toHaveBeenCalledWith('hourglass_top', ['icon-inline']);
       });
 
-      it('should not add any color class', () => {
+      it('should add status-loading class', () => {
         renderStatus(container, STATUS_TYPES.DELETING);
         
-        expect(container.classList.add).not.toHaveBeenCalled();
+        expect(container.classList.add).toHaveBeenCalledWith('status-loading');
       });
 
       it('should display deleting message if provided', () => {
@@ -337,11 +342,11 @@ describe('status-renderer', () => {
 
       it('should update color classes correctly', () => {
         renderStatus(container, STATUS_TYPES.SAVED);
-        expect(container.classList.add).toHaveBeenCalledWith('color-accent');
+        expect(container.classList.add).toHaveBeenCalledWith('status-saved');
         
         vi.clearAllMocks();
         renderStatus(container, STATUS_TYPES.ERROR);
-        expect(container.classList.add).toHaveBeenCalledWith('color-error');
+        expect(container.classList.add).toHaveBeenCalledWith('status-error');
       });
 
       it('should change labels correctly', () => {
@@ -366,7 +371,7 @@ describe('status-renderer', () => {
         vi.clearAllMocks();
         renderStatus(container, STATUS_TYPES.SUCCESS, 'Data loaded');
         expect(createIcon).toHaveBeenCalledWith('check_circle', ['icon-inline']);
-        expect(container.classList.add).toHaveBeenCalledWith('color-success');
+        expect(container.classList.add).toHaveBeenCalledWith('status-success');
       });
 
       it('should handle complete loading to error flow', async () => {
@@ -380,16 +385,16 @@ describe('status-renderer', () => {
         vi.clearAllMocks();
         renderStatus(container, STATUS_TYPES.ERROR, 'Processing failed');
         expect(createIcon).toHaveBeenCalledWith('error', ['icon-inline']);
-        expect(container.classList.add).toHaveBeenCalledWith('color-error');
+        expect(container.classList.add).toHaveBeenCalledWith('status-error');
       });
 
       it('should handle saved to not saved transition', async () => {
         renderStatus(container, STATUS_TYPES.SAVED);
-        expect(container.classList.add).toHaveBeenCalledWith('color-accent');
+        expect(container.classList.add).toHaveBeenCalledWith('status-saved');
         
         vi.clearAllMocks();
         renderStatus(container, STATUS_TYPES.NOT_SAVED);
-        expect(container.classList.add).toHaveBeenCalledWith('color-muted');
+        expect(container.classList.add).toHaveBeenCalledWith('status-not-saved');
       });
     });
   });


### PR DESCRIPTION
- Create src/styles/components/status.css with semantic status and utility classes
- Import status.css in src/styles.css
- Refactor src/modules/status-renderer.js to use semantic classes (status-saved, status-error, etc.) instead of generic color classes
- Refactor src/modules/repo-branch-selector.js to remove inline styles and use new utility classes
- Update version badge in src/styles/components/header.css to use semantic var(--warn)
- Update unit tests for status-renderer and repo-branch-selector to match changes

<img width="1280" height="77" alt="image" src="https://github.com/user-attachments/assets/27cc522b-fb1e-42b5-9f85-80185783511b" />

---
https://jules.google.com/session/5719030254054507954