### PR TITLE
Refactor element visibility to use CSS classes instead of inline styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
           <button id="freeInputSaveBtn" class="btn" title="Save content as a new prompt file"><span class="icon icon-inline" aria-hidden="true">save</span> Save</button>
           <div class="menu-anchor">
             <button id="freeInputCopenBtn" class="btn" title="Copy prompt and open in new tab"><span class="icon icon-inline" aria-hidden="true">open_in_new</span> Copen ▼</button>
-            <div id="freeInputCopenMenu" class="menu-panel menu-panel-sm menu-panel--above" style="display:none;">
+            <div id="freeInputCopenMenu" class="menu-panel menu-panel-sm menu-panel--above">
               <div class="custom-dropdown-item" data-target="blank"><span class="icon icon-inline" aria-hidden="true">public</span> Blank</div>
               <div class="custom-dropdown-item" data-target="claude"><span class="icon icon-inline" aria-hidden="true">smart_toy</span> Claude</div>
               <div class="custom-dropdown-item" data-target="codex"><span class="icon icon-inline" aria-hidden="true">forum</span> Codex</div>
@@ -118,7 +118,7 @@
         <button class="btn" id="copyBtn" title="Copy the entire prompt"><span class="icon icon-inline" aria-hidden="true">content_copy</span> Copy</button>
         <div class="menu-anchor">
           <button class="btn" id="copenBtn" title="Copy prompt and open in new tab"><span class="icon icon-inline" aria-hidden="true">open_in_new</span> copen ▼</button>
-          <div id="copenMenu" class="menu-panel menu-panel-sm menu-panel--below-left" style="display:none;">
+          <div id="copenMenu" class="menu-panel menu-panel-sm menu-panel--below-left">
             <div class="custom-dropdown-item" data-target="blank"><span class="icon icon-inline" aria-hidden="true">public</span> Blank</div>
             <div class="custom-dropdown-item" data-target="claude"><span class="icon icon-inline" aria-hidden="true">smart_toy</span> Claude</div>
             <div class="custom-dropdown-item" data-target="codex"><span class="icon icon-inline" aria-hidden="true">forum</span> Codex</div>
@@ -132,15 +132,15 @@
         <button class="btn" id="shareBtn" title="Copy a link to this prompt"><span class="icon icon-inline" aria-hidden="true">link</span> Copy link</button>
         <div class="menu-anchor">
           <button class="btn" id="moreBtn" title="More actions">⋯ More</button>
-          <div id="moreMenu" class="menu-panel menu-panel-md menu-panel--below-right" style="display:none;">
+          <div id="moreMenu" class="menu-panel menu-panel-md menu-panel--below-right">
             <div class="custom-dropdown-item" id="moreEditBtn"><span class="icon icon-inline" aria-hidden="true">edit</span> Edit on GitHub</div>
             <div class="custom-dropdown-item" id="moreGhBtn"><span class="icon icon-inline" aria-hidden="true">folder</span> View on GitHub</div>
             <div class="custom-dropdown-item" id="moreRawBtn"><span class="icon icon-inline" aria-hidden="true">description</span> Open raw</div>
           </div>
         </div>
-        <a class="btn" id="editBtn" target="_blank" rel="noopener" title="Edit the file on GitHub" style="display:none;"><span class="icon icon-inline" aria-hidden="true">edit</span> Edit on GitHub</a>
-        <a class="btn" id="ghBtn" target="_blank" rel="noopener" title="Open the file on GitHub" style="display:none;"><span class="icon icon-inline" aria-hidden="true">folder</span> View on GitHub</a>
-        <a class="btn" id="rawBtn" target="_blank" rel="noopener" title="Open the raw file" style="display:none;"><span class="icon icon-inline" aria-hidden="true">description</span> Open raw</a>
+        <a class="btn hidden" id="editBtn" target="_blank" rel="noopener" title="Edit the file on GitHub"><span class="icon icon-inline" aria-hidden="true">edit</span> Edit on GitHub</a>
+        <a class="btn hidden" id="ghBtn" target="_blank" rel="noopener" title="Open the file on GitHub"><span class="icon icon-inline" aria-hidden="true">folder</span> View on GitHub</a>
+        <a class="btn hidden" id="rawBtn" target="_blank" rel="noopener" title="Open the raw file"><span class="icon icon-inline" aria-hidden="true">description</span> Open raw</a>
       </div>
       <article id="content" class="scrollable-list list-lg"></article>
     </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -237,6 +238,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1066,6 +1068,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2036,6 +2039,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -2737,6 +2741,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2820,6 +2825,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/src/modules/dropdown.js
+++ b/src/modules/dropdown.js
@@ -20,7 +20,6 @@ function toggleDropdown(dropdown) {
 function openDropdown(dropdown) {
   closeAllDropdowns();
   dropdown.menu.classList.add('open');
-  dropdown.menu.style.display = ''; // Clear inline style if present
   dropdown.btn.setAttribute('aria-expanded', 'true');
   openDropdowns.add(dropdown);
 }

--- a/src/modules/jules-free-input.js
+++ b/src/modules/jules-free-input.js
@@ -333,7 +333,7 @@ export function showFreeInputForm() {
   
   copenBtn.onclick = (e) => {
     e.stopPropagation();
-    copenMenu.classList.toggle('show');
+    copenMenu.classList.toggle('open');
   };
   
   if (copenMenu) {
@@ -342,14 +342,14 @@ export function showFreeInputForm() {
         e.stopPropagation();
         const target = item.dataset.target;
         await handleCopen(target);
-        copenMenu.classList.remove('show');
+        copenMenu.classList.remove('open');
       };
     });
   }
   
   const closeCopenMenu = (e) => {
     if (!copenBtn.contains(e.target) && !copenMenu.contains(e.target)) {
-      copenMenu.classList.remove('show');
+      copenMenu.classList.remove('open');
     }
   };
   document.addEventListener('click', closeCopenMenu);

--- a/src/modules/prompt-renderer.js
+++ b/src/modules/prompt-renderer.js
@@ -1,7 +1,7 @@
 import { slugify } from '../utils/slug.js';
 import { isGistUrl, resolveGistRawUrl, fetchGistContent, fetchRawFile } from './github-api.js';
 import { CODEX_URL_REGEX, TIMEOUTS } from '../utils/constants.js';
-import { setElementDisplay } from '../utils/dom-helpers.js';
+import { setElementDisplay, toggleVisibility } from '../utils/dom-helpers.js';
 import { loadMarked } from '../utils/lazy-loaders.js';
 import { ensureAncestorsExpanded, loadExpandedState, persistExpandedState, renderList, updateActiveItem, setCurrentSlug, getCurrentSlug, getFiles } from './prompt-list.js';
 import { showToast } from './toast.js';
@@ -85,7 +85,7 @@ function handleDocumentClick(event) {
   if (target === copenBtn) {
     event.stopPropagation();
     if (copenMenu) {
-      copenMenu.style.display = copenMenu.style.display === 'none' ? 'block' : 'none';
+      copenMenu.classList.toggle('open');
     }
     return;
   }
@@ -95,7 +95,7 @@ function handleDocumentClick(event) {
     event.stopPropagation();
     const targetApp = copenMenuItem.dataset.target;
     handleCopenPrompt(targetApp);
-    copenMenu.style.display = 'none';
+    copenMenu.classList.remove('open');
     return;
   }
 
@@ -153,7 +153,7 @@ function handleDocumentClick(event) {
   if (target === moreBtn) {
     event.stopPropagation();
     if (moreMenu) {
-      moreMenu.style.display = moreMenu.style.display === 'none' ? 'block' : 'none';
+      moreMenu.classList.toggle('open');
     }
     return;
   }
@@ -167,7 +167,7 @@ function handleDocumentClick(event) {
     if (editBtn && editBtn.href) {
       window.open(editBtn.href, '_blank', 'noopener,noreferrer');
     }
-    if (moreMenu) moreMenu.style.display = 'none';
+    if (moreMenu) moreMenu.classList.remove('open');
     return;
   }
 
@@ -176,7 +176,7 @@ function handleDocumentClick(event) {
     if (ghBtn && ghBtn.href) {
       window.open(ghBtn.href, '_blank', 'noopener,noreferrer');
     }
-    if (moreMenu) moreMenu.style.display = 'none';
+    if (moreMenu) moreMenu.classList.remove('open');
     return;
   }
 
@@ -185,12 +185,12 @@ function handleDocumentClick(event) {
     if (rawBtn && rawBtn.href) {
       window.open(rawBtn.href, '_blank', 'noopener,noreferrer');
     }
-    if (moreMenu) moreMenu.style.display = 'none';
+    if (moreMenu) moreMenu.classList.remove('open');
     return;
   }
 
-  if (copenMenu) copenMenu.style.display = 'none';
-  if (moreMenu) moreMenu.style.display = 'none';
+  if (copenMenu) copenMenu.classList.remove('open');
+  if (moreMenu) moreMenu.classList.remove('open');
 }
 
 async function handleBranchChanged() {
@@ -257,14 +257,8 @@ export async function selectFile(f, pushHash, owner, repo, branch) {
   setElementDisplay(metaEl, true);
   setElementDisplay(actionsEl, true);
   
-  // Clear inline styles that might have been set by showFreeInputForm
-  if (titleEl) titleEl.style.display = '';
-  if (metaEl) metaEl.style.display = '';
-  if (actionsEl) actionsEl.style.display = '';
-  
   if (contentEl) {
-    contentEl.style.display = '';
-    contentEl.classList.remove('hidden');
+    toggleVisibility(contentEl, true);
   }
 
   titleEl.textContent = f.name.replace(/\.md$/i, '');
@@ -346,6 +340,10 @@ export async function selectFile(f, pushHash, owner, repo, branch) {
   const moreGhBtn = document.getElementById('moreGhBtn');
   const moreRawBtn = document.getElementById('moreRawBtn');
   
+  if (editBtn) toggleVisibility(editBtn, true);
+  if (ghBtn) toggleVisibility(ghBtn, true);
+  if (rawBtn) toggleVisibility(rawBtn, true);
+
   if (isGistContent && gistUrl) {
     editBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">edit</span> Edit Link';
     editBtn.title = 'Edit the gist link';

--- a/src/modules/repo-branch-selector.js
+++ b/src/modules/repo-branch-selector.js
@@ -1,5 +1,6 @@
 import { getCurrentUser } from './auth.js';
 import { showToast } from './toast.js';
+import { toggleVisibility } from '../utils/dom-helpers.js';
 
 function extractDefaultBranch(source) {
   const defaultBranchObj = source?.githubRepo?.defaultBranch ||
@@ -19,7 +20,7 @@ function setupClickOutsideClose(targetBtn, targetMenu) {
   
   const closeDropdown = (e) => {
     if (!targetBtn.contains(e.target) && !targetMenu.contains(e.target)) {
-      targetMenu.style.display = 'none';
+      targetMenu.classList.remove('open');
     }
   };
   
@@ -142,8 +143,8 @@ export class RepoSelector {
   setupDropdownToggle() {
     this.dropdownBtn.onclick = async (e) => {
       e.stopPropagation();
-      if (this.dropdownMenu.style.display === 'block') {
-        this.dropdownMenu.style.display = 'none';
+      if (this.dropdownMenu.classList.contains('open')) {
+        this.dropdownMenu.classList.remove('open');
         return;
       }
       
@@ -169,7 +170,7 @@ export class RepoSelector {
     loadingIndicator.style.cssText = 'padding:12px; text-align:center; color:var(--muted); font-size:13px;';
     loadingIndicator.textContent = 'Loading...';
     this.dropdownMenu.appendChild(loadingIndicator);
-    this.dropdownMenu.style.display = 'block';
+    this.dropdownMenu.classList.add('open');
     
     await new Promise(resolve => setTimeout(resolve, 0));
     
@@ -183,7 +184,7 @@ export class RepoSelector {
       this.renderAllRepos();
     }
     
-    this.dropdownMenu.style.display = 'block';
+    this.dropdownMenu.classList.add('open');
   }
 
   async renderFavorites() {
@@ -191,7 +192,7 @@ export class RepoSelector {
       const item = this.createRepoItem(fav.name, fav.id, true, async () => {
         this.selectedSourceId = fav.id;
         this.dropdownText.textContent = fav.name;
-        this.dropdownMenu.style.display = 'none';
+        this.dropdownMenu.classList.remove('open');
         
         // Save repo selection
         this.saveToStorage();
@@ -245,7 +246,7 @@ export class RepoSelector {
         }
       }
       
-      showMoreBtn.style.display = 'none';
+      toggleVisibility(showMoreBtn, false);
       this.renderAllRepos();
     };
     
@@ -296,7 +297,7 @@ export class RepoSelector {
       const item = this.createRepoItem(repoName, source.name || source.id, false, () => {
         this.selectedSourceId = source.name || source.id;
         this.dropdownText.textContent = repoName;
-        this.dropdownMenu.style.display = 'none';
+        this.dropdownMenu.classList.remove('open');
         
         // Save repo selection
         this.saveToStorage();
@@ -326,7 +327,7 @@ export class RepoSelector {
       e.stopPropagation();
       if (isFavorite) {
         await this.removeFavorite(id);
-        this.dropdownMenu.style.display = 'none';
+        this.dropdownMenu.classList.remove('open');
         setTimeout(() => this.populateDropdown(), 0);
       } else {
         const defaultBranch = extractDefaultBranch(this.allSources.find(s => (s.name || s.id) === id));
@@ -520,8 +521,8 @@ export class BranchSelector {
   setupDropdownToggle() {
     this.dropdownBtn.onclick = (e) => {
       e.stopPropagation();
-      if (this.dropdownMenu.style.display === 'block') {
-        this.dropdownMenu.style.display = 'none';
+      if (this.dropdownMenu.classList.contains('open')) {
+        this.dropdownMenu.classList.remove('open');
         return;
       }
       
@@ -551,7 +552,7 @@ export class BranchSelector {
     const currentItem = document.createElement('div');
     currentItem.className = 'dropdown-item-with-star selected';
     currentItem.onclick = () => {
-      this.dropdownMenu.style.display = 'none';
+      this.dropdownMenu.classList.remove('open');
     };
     
     // Hide star for current item
@@ -593,7 +594,7 @@ export class BranchSelector {
         }
 
         this.allBranchesLoaded = true;
-        showMoreBtn.style.display = 'none';
+        toggleVisibility(showMoreBtn, false);
         
         allBranches.forEach(branch => {
           if (branch.name === this.selectedBranch) return;
@@ -612,7 +613,7 @@ export class BranchSelector {
           
           item.onclick = () => {
             this.setSelectedBranch(branch.name);
-            this.dropdownMenu.style.display = 'none';
+            this.dropdownMenu.classList.remove('open');
           };
           
           item.appendChild(star);
@@ -629,7 +630,7 @@ export class BranchSelector {
     
     this.dropdownMenu.appendChild(showMoreBtn);
     
-    this.dropdownMenu.style.display = 'block';
+    this.dropdownMenu.classList.add('open');
   }
 
   setSelectedBranch(branch) {

--- a/src/styles/components/content.css
+++ b/src/styles/components/content.css
@@ -52,6 +52,7 @@ a:hover { text-decoration: underline; }
 .actions-right { display: flex; gap: 8px; justify-content: flex-end; }
 .menu-anchor { position: relative; display: inline-block; }
 .menu-panel { display: none; position: absolute; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); z-index: 1000; }
+.menu-panel.open { display: block; }
 .menu-panel-sm { min-width: 150px; }
 .menu-panel-md { min-width: 180px; }
 .menu-panel--above { bottom: 100%; left: 0; margin-bottom: 4px; }

--- a/src/tests/utils/dom-helpers.test.js
+++ b/src/tests/utils/dom-helpers.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { 
   createElement, 
   createIcon, 
+  toggleVisibility,
   setElementDisplay, 
   toggleClass, 
   clearElement, 
@@ -119,6 +120,45 @@ describe('DOM Helpers', () => {
       const icon = createIcon('default');
       
       expect(icon.getAttribute('aria-hidden')).toBe('true');
+    });
+  });
+
+  describe('toggleVisibility', () => {
+    it('should toggle .hidden class if shouldShow is undefined', () => {
+      const el = document.createElement('div');
+
+      toggleVisibility(el);
+      expect(el.classList.contains('hidden')).toBe(true);
+
+      toggleVisibility(el);
+      expect(el.classList.contains('hidden')).toBe(false);
+    });
+
+    it('should remove .hidden class if shouldShow is true', () => {
+      const el = document.createElement('div');
+      el.classList.add('hidden');
+
+      toggleVisibility(el, true);
+      expect(el.classList.contains('hidden')).toBe(false);
+
+      // Should stay visible
+      toggleVisibility(el, true);
+      expect(el.classList.contains('hidden')).toBe(false);
+    });
+
+    it('should add .hidden class if shouldShow is false', () => {
+      const el = document.createElement('div');
+
+      toggleVisibility(el, false);
+      expect(el.classList.contains('hidden')).toBe(true);
+
+      // Should stay hidden
+      toggleVisibility(el, false);
+      expect(el.classList.contains('hidden')).toBe(true);
+    });
+
+    it('should handle null element', () => {
+      expect(() => toggleVisibility(null)).not.toThrow();
     });
   });
 

--- a/src/utils/dom-helpers.js
+++ b/src/utils/dom-helpers.js
@@ -19,8 +19,18 @@ export function createIcon(iconName, classes = [], ariaHidden = true) {
   if (ariaHidden) span.setAttribute('aria-hidden', 'true');
   return span;
 }
+
+export function toggleVisibility(el, shouldShow) {
+  if (!el) return;
+  if (shouldShow === undefined) {
+    el.classList.toggle('hidden');
+  } else {
+    el.classList.toggle('hidden', !shouldShow);
+  }
+}
+
 export function setElementDisplay(el, show = true) {
-  el.classList.toggle('hidden', !show);
+  toggleVisibility(el, show);
 }
 
 export function toggleClass(el, className, force) {


### PR DESCRIPTION
- Added `toggleVisibility` helper in `src/utils/dom-helpers.js`.
- Updated `src/modules/prompt-renderer.js` to use `toggleVisibility` and class-based menu toggling (`.open`).
- Updated `src/modules/repo-branch-selector.js` to use class-based visibility for dropdowns (`.open`) and `toggleVisibility` for elements.
- Updated `src/modules/dropdown.js` to remove inline style clearing.
- Updated `src/modules/jules-free-input.js` to use `.open` class for menus.
- Updated `index.html` to remove `style="display:none"` from initial elements and use classes instead.
- Added `.menu-panel.open` to `src/styles/components/content.css`.
- Added unit tests for `toggleVisibility`.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/3e4c1ded-aa77-417a-aa5f-82108a54aa7b" />

---
https://jules.google.com/session/2344292313856640962