### PR TITLE
Refactor Firebase services to eliminate global variables

### DIFF
--- a/src/firebase-init.js
+++ b/src/firebase-init.js
@@ -2,6 +2,7 @@
 // This file initializes Firebase using the modular SDK
 
 import { TIMEOUTS, LIMITS } from './utils/constants.js';
+import { initServices } from './modules/firebase-service.js';
 
 // Firebase configuration
 const firebaseConfig = {
@@ -22,8 +23,29 @@ function initFirebaseWhenReady() {
       const app = firebase.initializeApp(firebaseConfig);
       
       // Get services - compat API doesn't require app parameter
-      window.auth = firebase.auth();
-      window.db = firebase.firestore();
+      const auth = firebase.auth();
+      const db = firebase.firestore();
+
+      // Initialize services module
+      initServices(auth, db, null);
+
+      // Backward compatibility with deprecation warnings
+      Object.defineProperty(window, 'auth', {
+        get: () => {
+          console.warn('DEPRECATED: window.auth is deprecated. Use getAuth() from modules/firebase-service.js');
+          return auth;
+        },
+        configurable: true
+      });
+
+      Object.defineProperty(window, 'db', {
+        get: () => {
+          console.warn('DEPRECATED: window.db is deprecated. Use getDb() from modules/firebase-service.js');
+          return db;
+        },
+        configurable: true
+      });
+
       // Functions removed - not used in this app (uses direct REST API calls)
       
       // Port 5000 = dev server with emulators, port 3000 = production
@@ -33,7 +55,7 @@ function initFirebaseWhenReady() {
         try {
           // Use the same hostname as the page to avoid CORS issues
           const emulatorHost = window.location.hostname;
-          window.db.useEmulator(emulatorHost, 8090);
+          db.useEmulator(emulatorHost, 8090);
           console.log('🔧 Connected to Firebase Emulators (Firestore)');
           console.log('⚠️ Dev server - using test data only');
         } catch (emulatorError) {

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -2,13 +2,15 @@
 
 import { showToast } from './toast.js';
 import { setCache, getCache } from '../utils/session-cache.js';
+import { getAuth } from './firebase-service.js';
 // Lazy loaded: jules-api.js (for clearJulesKeyCache)
 
 let currentUser = null;
 
 export function getCurrentUser() {
-  if (window.auth?.currentUser && window.auth.currentUser !== currentUser) {
-    currentUser = window.auth.currentUser;
+  const auth = getAuth();
+  if (auth?.currentUser && auth.currentUser !== currentUser) {
+    currentUser = auth.currentUser;
   }
   return currentUser;
 }
@@ -19,7 +21,8 @@ export function setCurrentUser(user) {
 
 export async function signInWithGitHub(forceAccountSelection = false) {
   try {
-    if (!window.auth) {
+    const auth = getAuth();
+    if (!auth) {
       showToast('Authentication not ready. Please refresh the page.', 'error');
       return;
     }
@@ -33,7 +36,7 @@ export async function signInWithGitHub(forceAccountSelection = false) {
       });
     }
     
-    const result = await window.auth.signInWithPopup(provider);
+    const result = await auth.signInWithPopup(provider);
     
     if (result.credential && result.credential.accessToken) {
       const tokenData = {
@@ -57,7 +60,8 @@ export async function switchGitHubAccount() {
     showToast('Switching accounts...', 'info');
     
     // Sign out the current user first
-    if (window.auth?.currentUser) {
+    const auth = getAuth();
+    if (auth?.currentUser) {
       await signOutUser();
     }
     
@@ -71,13 +75,14 @@ export async function switchGitHubAccount() {
 
 export async function signOutUser() {
   try {
-    if (window.auth) {
+    const auth = getAuth();
+    if (auth) {
       // Clear Jules API key cache on logout
-      if (window.auth.currentUser) {
+      if (auth.currentUser) {
         const { clearJulesKeyCache } = await import('./jules-api.js');
-        clearJulesKeyCache(window.auth.currentUser.uid);
+        clearJulesKeyCache(auth.currentUser.uid);
       }
-      await window.auth.signOut();
+      await auth.signOut();
       localStorage.removeItem('github_access_token');
     }
   } catch (error) {
@@ -191,11 +196,12 @@ export async function updateAuthUI(user) {
 
 export function initAuthStateListener() {
   try {
-    if (!window.auth) {
+    const auth = getAuth();
+    if (!auth) {
       console.error('Auth not initialized yet');
       return;
     }
-    window.auth.onAuthStateChanged((user) => {
+    auth.onAuthStateChanged((user) => {
       updateAuthUI(user);
     });
   } catch (error) {

--- a/src/modules/firebase-service.js
+++ b/src/modules/firebase-service.js
@@ -1,0 +1,74 @@
+let authInstance = null;
+let dbInstance = null;
+let functionsInstance = null;
+let readyCallbacks = [];
+let isReady = false;
+
+/**
+ * Initialize the Firebase services
+ * @param {Object} auth - The Firebase Auth instance
+ * @param {Object} db - The Firebase Firestore instance
+ * @param {Object} functions - The Firebase Functions instance
+ */
+export function initServices(auth, db, functions) {
+  authInstance = auth;
+  dbInstance = db;
+  functionsInstance = functions;
+  isReady = true;
+
+  // Execute all queued callbacks
+  readyCallbacks.forEach(callback => {
+    try {
+      callback();
+    } catch (e) {
+      console.error('Error in firebase ready callback:', e);
+    }
+  });
+  readyCallbacks = [];
+}
+
+/**
+ * Get the Firebase Auth instance
+ * @returns {Object|null} The Firebase Auth instance
+ */
+export function getAuth() {
+  if (!authInstance) {
+    console.warn('Firebase Auth accessed before initialization');
+  }
+  return authInstance;
+}
+
+/**
+ * Get the Firebase Firestore instance
+ * @returns {Object|null} The Firebase Firestore instance
+ */
+export function getDb() {
+  if (!dbInstance) {
+    console.warn('Firebase DB accessed before initialization');
+  }
+  return dbInstance;
+}
+
+/**
+ * Get the Firebase Functions instance
+ * @returns {Object|null} The Firebase Functions instance
+ */
+export function getFunctions() {
+  return functionsInstance;
+}
+
+/**
+ * Register a callback to run when Firebase is ready
+ * @param {Function} callback - The callback function
+ */
+export function onFirebaseReady(callback) {
+  if (isReady) {
+    try {
+      callback();
+    } catch (e) {
+      console.error('Error in firebase ready callback:', e);
+    }
+  } else {
+    readyCallbacks.push(callback);
+  }
+}


### PR DESCRIPTION
Introduced `src/modules/firebase-service.js` to manage Firebase service instances via ES6 exports (`getAuth`, `getDb`, `getFunctions`), replacing direct global `window` assignments. 

Updated `src/firebase-init.js` to initialize this service module and added deprecation warnings for `window.auth` and `window.db` to maintain temporary backward compatibility.

Migrated `src/modules/auth.js` to use the new service module and updated its unit tests in `src/tests/modules/auth.test.js` to mock `firebase-service.js` instead of global objects.

---
https://jules.google.com/session/8902131175840560309