### PR TITLE
Remove unused DOM helpers onElement and stopPropagation

### DIFF
--- a/src/tests/utils/dom-helpers.test.js
+++ b/src/tests/utils/dom-helpers.test.js
@@ -4,9 +4,7 @@ import {
   createIcon, 
   setElementDisplay, 
   toggleClass, 
-  clearElement, 
-  onElement, 
-  stopPropagation 
+  clearElement
 } from '../../utils/dom-helpers.js';
 
 describe('DOM Helpers', () => {
@@ -248,73 +246,4 @@ describe('DOM Helpers', () => {
     });
   });
 
-  describe('onElement', () => {
-    it('should add event listener to element', () => {
-      const el = document.createElement('button');
-      const handler = vi.fn();
-      
-      onElement(el, 'click', handler);
-      el.click();
-      
-      expect(handler).toHaveBeenCalledTimes(1);
-    });
-
-    it('should handle multiple event types', () => {
-      const el = document.createElement('input');
-      const handler = vi.fn();
-      
-      onElement(el, 'input', handler);
-      el.dispatchEvent(new Event('input'));
-      
-      expect(handler).toHaveBeenCalled();
-    });
-
-    it('should do nothing if element is null', () => {
-      const handler = vi.fn();
-      
-      expect(() => {
-        onElement(null, 'click', handler);
-      }).not.toThrow();
-      
-      expect(handler).not.toHaveBeenCalled();
-    });
-
-    it('should do nothing if element is undefined', () => {
-      const handler = vi.fn();
-      
-      expect(() => {
-        onElement(undefined, 'click', handler);
-      }).not.toThrow();
-      
-      expect(handler).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('stopPropagation', () => {
-    it('should call stopPropagation on event', () => {
-      const event = new Event('click', { bubbles: true });
-      const spy = vi.spyOn(event, 'stopPropagation');
-      
-      stopPropagation(event);
-      
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('should prevent event bubbling', () => {
-      const parent = document.createElement('div');
-      const child = document.createElement('button');
-      parent.appendChild(child);
-      
-      const parentHandler = vi.fn();
-      const childHandler = vi.fn((e) => stopPropagation(e));
-      
-      parent.addEventListener('click', parentHandler);
-      child.addEventListener('click', childHandler);
-      
-      child.click();
-      
-      expect(childHandler).toHaveBeenCalled();
-      expect(parentHandler).not.toHaveBeenCalled();
-    });
-  });
 });

--- a/src/utils/dom-helpers.js
+++ b/src/utils/dom-helpers.js
@@ -39,14 +39,6 @@ export function clearElement(el) {
   }
 }
 
-export function onElement(el, event, handler) {
-  if (el) el.addEventListener(event, handler);
-}
-
-export function stopPropagation(e) {
-  e.stopPropagation();
-}
-
 export function waitForDOMReady(callback) {
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', callback);


### PR DESCRIPTION
Removed unused exports onElement and stopPropagation from src/utils/dom-helpers.js and their corresponding tests from src/tests/utils/dom-helpers.test.js. These functions were not used in the application code.

---
https://jules.google.com/session/6059430758333576486