### PR TITLE
Convert status-bar.js to named export pattern

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@
 
 import { OWNER, REPO, BRANCH, STORAGE_KEYS } from './utils/constants.js';
 import { parseParams, getHashParam } from './utils/url-params.js';
-import statusBar from './modules/status-bar.js';
+import { statusBar } from './modules/status-bar.js';
 import { initPromptList, loadList, loadExpandedState, renderList, setSelectFileCallback, setRepoContext } from './modules/prompt-list.js';
 import { initPromptRenderer, selectBySlug, selectFile, setHandleTryInJulesCallback } from './modules/prompt-renderer.js';
 import { setCurrentBranch, setCurrentRepo, loadBranchFromStorage } from './modules/branch-selector.js';

--- a/src/modules/jules-queue.js
+++ b/src/modules/jules-queue.js
@@ -1,5 +1,5 @@
 import { extractTitleFromPrompt } from '../utils/title.js';
-import statusBar from './status-bar.js';
+import { statusBar } from './status-bar.js';
 import { createModal } from '../utils/modal-manager.js';
 import { getCache, setCache, CACHE_KEYS } from '../utils/session-cache.js';
 import { RepoSelector, BranchSelector } from './repo-branch-selector.js';

--- a/src/modules/jules-subtask-modal.js
+++ b/src/modules/jules-subtask-modal.js
@@ -11,7 +11,7 @@ import { callRunJulesFunction } from './jules-api.js';
 import { showToast } from './toast.js';
 import { showConfirm } from './confirm-modal.js';
 import { extractTitleFromPrompt } from '../utils/title.js';
-import statusBar from './status-bar.js';
+import { statusBar } from './status-bar.js';
 import { JULES_MESSAGES, TIMEOUTS, RETRY_CONFIG } from '../utils/constants.js';
 
 // Module state

--- a/src/modules/prompt-renderer.js
+++ b/src/modules/prompt-renderer.js
@@ -7,7 +7,7 @@ import { ensureAncestorsExpanded, loadExpandedState, persistExpandedState, rende
 import { showToast } from './toast.js';
 import { copyAndOpen } from './copen.js';
 import { copyText } from '../utils/clipboard.js';
-import statusBar from './status-bar.js';
+import { statusBar } from './status-bar.js';
 
 function sanitizeHtml(html) {
   if (typeof window.DOMPurify === 'undefined') {

--- a/src/modules/status-bar.js
+++ b/src/modules/status-bar.js
@@ -102,4 +102,4 @@ class StatusBar {
 }
 
 const statusBar = new StatusBar();
-export default statusBar;
+export { statusBar };

--- a/src/shared-init.js
+++ b/src/shared-init.js
@@ -6,7 +6,7 @@ import { initAuthStateListener } from './modules/auth.js';
 import { initBranchSelector, loadBranches, loadBranchFromStorage } from './modules/branch-selector.js';
 import { OWNER, REPO, BRANCH, ERRORS } from './utils/constants.js';
 import { parseParams } from './utils/url-params.js';
-import statusBar from './modules/status-bar.js';
+import { statusBar } from './modules/status-bar.js';
 import { getFirebaseReady } from './firebase-init.js';
 import { waitForDOMReady } from './utils/dom-helpers.js';
 import { fetchJSON } from './modules/github-api.js';

--- a/src/tests/modules/jules-queue.test.js
+++ b/src/tests/modules/jules-queue.test.js
@@ -18,7 +18,7 @@ vi.mock('../../utils/title.js', () => ({
 }));
 
 vi.mock('../../modules/status-bar.js', () => ({
-  default: {
+  statusBar: {
     show: vi.fn(),
     hide: vi.fn(),
     update: vi.fn()

--- a/src/tests/modules/prompt-renderer.test.js
+++ b/src/tests/modules/prompt-renderer.test.js
@@ -61,7 +61,7 @@ vi.mock('../../modules/copen.js', () => ({
 }));
 
 vi.mock('../../modules/status-bar.js', () => ({
-  default: {
+  statusBar: {
     setActivity: vi.fn(),
     clearActivity: vi.fn(),
     showMessage: vi.fn()

--- a/src/tests/modules/status-bar.test.js
+++ b/src/tests/modules/status-bar.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import statusBar from '../../modules/status-bar.js';
+import { statusBar } from '../../modules/status-bar.js';
 import { TIMEOUTS } from '../../utils/constants.js';
 
 describe('status-bar', () => {

--- a/src/tests/utils/error-handler.test.js
+++ b/src/tests/utils/error-handler.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { handleError, ErrorCategory } from '../../utils/error-handler.js';
 import * as toastModule from '../../modules/toast.js';
-import statusBar from '../../modules/status-bar.js';
+import { statusBar } from '../../modules/status-bar.js';
 
 // Mock dependencies
 vi.mock('../../modules/toast.js', () => ({
@@ -13,7 +13,7 @@ vi.mock('../../modules/toast.js', () => ({
 }));
 
 vi.mock('../../modules/status-bar.js', () => ({
-  default: {
+  statusBar: {
     showMessage: vi.fn(),
     hide: vi.fn()
   }

--- a/src/utils/error-handler.js
+++ b/src/utils/error-handler.js
@@ -4,7 +4,7 @@
  */
 
 import { showToast } from '../modules/toast.js';
-import statusBar from '../modules/status-bar.js';
+import { statusBar } from '../modules/status-bar.js';
 import { TIMEOUTS } from './constants.js';
 
 export const ErrorCategory = {


### PR DESCRIPTION
- Change export from default to named export in `src/modules/status-bar.js`
- Update imports in `src/app.js`, `src/utils/error-handler.js`, `src/shared-init.js`, `src/modules/jules-subtask-modal.js`, `src/modules/jules-queue.js`, `src/modules/prompt-renderer.js`
- Update test mocks in `src/tests/utils/error-handler.test.js`, `src/tests/modules/status-bar.test.js`, `src/tests/modules/jules-queue.test.js`, `src/tests/modules/prompt-renderer.test.js`

---
https://jules.google.com/session/5402131619567644743