### PR TITLE
Refactor sessions page to use CSS classes and createElement

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -141,7 +141,15 @@ html, body {
   color: var(--muted);
 }
 
+.muted {
+  color: var(--muted);
+}
+
 .color-error {
+  color: var(--error);
+}
+
+.error-text {
   color: var(--error);
 }
 

--- a/src/styles/components/utilities.css
+++ b/src/styles/components/utilities.css
@@ -26,6 +26,7 @@
 /* Spacing - Padding */
 .pad-8 { padding: 8px; }
 .pad-24 { padding: 24px; }
+.pad-lg { padding: 24px; }
 
 /* Dimensions */
 .max-w-700 { max-width: 700px; }
@@ -34,6 +35,7 @@
 
 /* Typography */
 .text-align-center { text-align: center; }
+.text-center { text-align: center; }
 .text-truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .font-sm { font-size: 12px; }
 .font-13 { font-size: 13px; }


### PR DESCRIPTION
Replaces inline styles with utility classes (.error-text, .muted, .text-center, .pad-lg) and refactors DOM generation to use createElement instead of innerHTML for better security and maintainability. Verify error state handling.

---
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/03312a70-3c82-4d74-a996-64ddc8b65f44" />
