### PR TITLE
Add keyboard & focus handling to prompt dropdown menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,12 +99,12 @@
           <div class="menu-anchor">
             <button id="freeInputCopenBtn" class="btn" title="Copy prompt and open in new tab"><span class="icon icon-inline" aria-hidden="true">open_in_new</span> Copen ▼</button>
             <div id="freeInputCopenMenu" class="menu-panel menu-panel-sm menu-panel--above hidden">
-              <div class="custom-dropdown-item" data-target="blank"><span class="icon icon-inline" aria-hidden="true">public</span> Blank</div>
-              <div class="custom-dropdown-item" data-target="claude"><span class="icon icon-inline" aria-hidden="true">smart_toy</span> Claude</div>
-              <div class="custom-dropdown-item" data-target="codex"><span class="icon icon-inline" aria-hidden="true">forum</span> Codex</div>
-              <div class="custom-dropdown-item" data-target="copilot"><span class="icon icon-inline" aria-hidden="true">code</span> Copilot</div>
-              <div class="custom-dropdown-item" data-target="gemini"><span class="icon icon-inline" aria-hidden="true">auto_awesome</span> Gemini</div>
-              <div class="custom-dropdown-item" data-target="chatgpt"><span class="icon icon-inline" aria-hidden="true">chat</span> ChatGPT</div>
+              <div class="custom-dropdown-item" data-target="blank" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">public</span> Blank</div>
+              <div class="custom-dropdown-item" data-target="claude" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">smart_toy</span> Claude</div>
+              <div class="custom-dropdown-item" data-target="codex" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">forum</span> Codex</div>
+              <div class="custom-dropdown-item" data-target="copilot" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">code</span> Copilot</div>
+              <div class="custom-dropdown-item" data-target="gemini" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">auto_awesome</span> Gemini</div>
+              <div class="custom-dropdown-item" data-target="chatgpt" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">chat</span> ChatGPT</div>
             </div>
           </div>
           <button id="freeInputCancelBtn" class="btn"><span class="icon icon-inline" aria-hidden="true">clear</span> Clear</button>
@@ -120,12 +120,12 @@
         <div class="menu-anchor">
           <button class="btn" id="copenBtn" title="Copy prompt and open in new tab"><span class="icon icon-inline" aria-hidden="true">open_in_new</span> Copen ▼</button>
           <div id="copenMenu" class="menu-panel menu-panel-sm menu-panel--below-left hidden">
-            <div class="custom-dropdown-item" data-target="blank"><span class="icon icon-inline" aria-hidden="true">public</span> Blank</div>
-            <div class="custom-dropdown-item" data-target="claude"><span class="icon icon-inline" aria-hidden="true">smart_toy</span> Claude</div>
-            <div class="custom-dropdown-item" data-target="codex"><span class="icon icon-inline" aria-hidden="true">forum</span> Codex</div>
-            <div class="custom-dropdown-item" data-target="copilot"><span class="icon icon-inline" aria-hidden="true">code</span> Copilot</div>
-            <div class="custom-dropdown-item" data-target="gemini"><span class="icon icon-inline" aria-hidden="true">auto_awesome</span> Gemini</div>
-            <div class="custom-dropdown-item" data-target="chatgpt"><span class="icon icon-inline" aria-hidden="true">chat</span> ChatGPT</div>
+            <div class="custom-dropdown-item" data-target="blank" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">public</span> Blank</div>
+            <div class="custom-dropdown-item" data-target="claude" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">smart_toy</span> Claude</div>
+            <div class="custom-dropdown-item" data-target="codex" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">forum</span> Codex</div>
+            <div class="custom-dropdown-item" data-target="copilot" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">code</span> Copilot</div>
+            <div class="custom-dropdown-item" data-target="gemini" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">auto_awesome</span> Gemini</div>
+            <div class="custom-dropdown-item" data-target="chatgpt" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">chat</span> ChatGPT</div>
           </div>
         </div>
         <button class="btn" id="julesBtn" title="Try this prompt in Jules"><span class="icon icon-inline" aria-hidden="true">smart_toy</span> Try in Jules</button>
@@ -134,9 +134,9 @@
         <div class="menu-anchor">
           <button class="btn" id="moreBtn" title="More actions">⋯ More</button>
           <div id="moreMenu" class="menu-panel menu-panel-md menu-panel--below-right hidden">
-            <div class="custom-dropdown-item" id="moreEditBtn"><span class="icon icon-inline" aria-hidden="true">edit</span> Edit on GitHub</div>
-            <div class="custom-dropdown-item" id="moreGhBtn"><span class="icon icon-inline" aria-hidden="true">folder</span> View on GitHub</div>
-            <div class="custom-dropdown-item" id="moreRawBtn"><span class="icon icon-inline" aria-hidden="true">description</span> Open raw</div>
+            <div class="custom-dropdown-item" id="moreEditBtn" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">edit</span> Edit on GitHub</div>
+            <div class="custom-dropdown-item" id="moreGhBtn" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">folder</span> View on GitHub</div>
+            <div class="custom-dropdown-item" id="moreRawBtn" role="menuitem" tabindex="0"><span class="icon icon-inline" aria-hidden="true">description</span> Open raw</div>
           </div>
         </div>
         <a class="btn" id="editBtn" target="_blank" rel="noopener" title="Edit the file on GitHub" style="display:none;"><span class="icon icon-inline" aria-hidden="true">edit</span> Edit on GitHub</a>

--- a/src/modules/prompt-renderer.js
+++ b/src/modules/prompt-renderer.js
@@ -90,11 +90,15 @@ export function initPromptRenderer() {
   moreBtn = document.getElementById('moreBtn');
 
   document.addEventListener('click', handleDocumentClick);
+  document.addEventListener('keydown', handleDocumentKeydown);
+  document.addEventListener('focusin', handleDocumentFocusIn);
   window.addEventListener('branchChanged', handleBranchChanged);
 }
 
 export function destroyPromptRenderer() {
   document.removeEventListener('click', handleDocumentClick);
+  document.removeEventListener('keydown', handleDocumentKeydown);
+  document.removeEventListener('focusin', handleDocumentFocusIn);
   window.removeEventListener('branchChanged', handleBranchChanged);
   cacheRaw.clear();
   currentPromptText = null;
@@ -105,10 +109,28 @@ export function destroyPromptRenderer() {
   }
 }
 
+function getPromptMenus() {
+  return {
+    copenMenu: document.getElementById('copenMenu'),
+    moreMenu: document.getElementById('moreMenu')
+  };
+}
+
+function closePromptMenus() {
+  const { copenMenu, moreMenu } = getPromptMenus();
+  if (copenMenu) copenMenu.classList.add('hidden');
+  if (moreMenu) moreMenu.classList.add('hidden');
+}
+
+function toggleMenu(menu) {
+  if (menu) {
+    menu.classList.toggle('hidden');
+  }
+}
+
 function handleDocumentClick(event) {
   const target = event.target;
-  const copenMenu = document.getElementById('copenMenu');
-  const moreMenu = document.getElementById('moreMenu');
+  const { copenMenu, moreMenu } = getPromptMenus();
 
   if (target === copyBtn) {
     handleCopyPrompt();
@@ -117,9 +139,7 @@ function handleDocumentClick(event) {
 
   if (target === copenBtn) {
     event.stopPropagation();
-    if (copenMenu) {
-      copenMenu.classList.toggle('hidden');
-    }
+    toggleMenu(copenMenu);
     return;
   }
 
@@ -185,9 +205,7 @@ function handleDocumentClick(event) {
 
   if (target === moreBtn) {
     event.stopPropagation();
-    if (moreMenu) {
-      moreMenu.classList.toggle('hidden');
-    }
+    toggleMenu(moreMenu);
     return;
   }
 
@@ -222,8 +240,42 @@ function handleDocumentClick(event) {
     return;
   }
 
-  if (copenMenu) copenMenu.classList.add('hidden');
-  if (moreMenu) moreMenu.classList.add('hidden');
+  closePromptMenus();
+}
+
+function handleDocumentKeydown(event) {
+  const { key, target } = event;
+  if (key === 'Escape') {
+    closePromptMenus();
+    return;
+  }
+
+  if (key !== 'Enter' && key !== ' ' && key !== 'Spacebar') {
+    return;
+  }
+
+  const actionTarget = target.closest(
+    '#copenBtn, #moreBtn, #moreEditBtn, #moreGhBtn, #moreRawBtn, .custom-dropdown-item[data-target]'
+  );
+
+  if (!actionTarget) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  actionTarget.click();
+}
+
+function handleDocumentFocusIn(event) {
+  const target = event.target;
+  const { copenMenu, moreMenu } = getPromptMenus();
+  const inCopen = copenMenu && (copenMenu.contains(target) || (copenBtn && copenBtn.contains(target)));
+  const inMore = moreMenu && (moreMenu.contains(target) || (moreBtn && moreBtn.contains(target)));
+
+  if (!inCopen && !inMore) {
+    closePromptMenus();
+  }
 }
 
 async function handleBranchChanged() {


### PR DESCRIPTION
### Motivation
- Improve accessibility and usability of the prompt action menus so Escape closes menus, Enter/Space activate items, and menus close when focus moves away.

### Description
- Added global `keydown` and `focusin` handlers and helper functions (`getPromptMenus`, `closePromptMenus`, `toggleMenu`) to `src/modules/prompt-renderer.js` to support Escape to close menus, and Enter/Space to activate toggle buttons and menu items.
- Centralized open/close logic so click, key, and focus events consistently hide/show the `copenMenu` and `moreMenu`.
- Made dropdown items focusable and accessible by adding `role="menuitem"` and `tabindex="0"` to items in `index.html` (both free-input and main prompt menus) to enable keyboard activation.
- Registered/unregistered the added event listeners in `initPromptRenderer`/`destroyPromptRenderer` to avoid leaks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69751b4175c0832b8001a1ef14f6cb8b)