### PR TITLE
Add sessionStorage caching to version check logic

### DIFF
--- a/src/modules/version-check.js
+++ b/src/modules/version-check.js
@@ -1,0 +1,132 @@
+import { fetchJSON } from './github-api.js';
+import { OWNER, REPO, BRANCH, CACHE_KEYS, CACHE_DURATIONS } from '../utils/constants.js';
+
+function showUpdateBanner(latestDate, latestSha) {
+  if (document.getElementById('updateBanner')) return;
+
+  const banner = document.createElement('div');
+  banner.id = 'updateBanner';
+  banner.classList.add('update-banner');
+
+  const message = document.createElement('span');
+  message.textContent = `Update available: v${latestDate} (${latestSha})`;
+  message.classList.add('update-banner__message');
+
+  const buttonContainer = document.createElement('div');
+  buttonContainer.classList.add('update-banner__actions');
+
+  const refreshButton = document.createElement('button');
+  refreshButton.textContent = 'Refresh';
+  refreshButton.classList.add('update-banner__button');
+  refreshButton.addEventListener('click', () => {
+    window.location.reload();
+  });
+
+  const dismissButton = document.createElement('button');
+  dismissButton.textContent = '×';
+  dismissButton.classList.add('update-banner__dismiss');
+  dismissButton.addEventListener('click', () => {
+    localStorage.setItem(`dismissed-version-${latestSha}`, 'true');
+    banner.remove();
+    document.body.classList.remove('has-version-banner');
+  });
+
+  buttonContainer.appendChild(refreshButton);
+  buttonContainer.appendChild(dismissButton);
+
+  banner.appendChild(message);
+  banner.appendChild(buttonContainer);
+
+  document.body.insertBefore(banner, document.body.firstChild);
+
+  document.body.classList.add('has-version-banner');
+}
+
+function processVersionData(latestData, appVersion) {
+  const latestSha = latestData.sha.substring(0, 7);
+  const latestDate = new Date(latestData.commit.committer.date);
+  const latestDateStr = latestDate.toLocaleDateString('en-CA'); // YYYY-MM-DD
+
+  const currentVersionMeta = document.querySelector('meta[name="app-version"]');
+  let currentDate = latestDate;
+  let currentSha = latestSha;
+  let currentDateStr = latestDateStr;
+
+  if (currentVersionMeta) {
+    const versionContent = currentVersionMeta.content; // Format: "sha|date"
+    const [metaSha, metaDate] = versionContent.split('|');
+    if (metaSha && metaDate) {
+      currentSha = metaSha;
+      currentDate = new Date(metaDate);
+      currentDateStr = new Date(metaDate).toLocaleDateString('en-CA');
+    }
+  }
+
+  if (currentDate < latestDate) {
+    appVersion.textContent = `v${currentDateStr} (${currentSha})`;
+    appVersion.classList.add('version-badge', 'status-outdated');
+  } else {
+    appVersion.textContent = `v${latestDateStr} (${latestSha})`;
+    appVersion.classList.add('version-badge');
+    appVersion.classList.remove('status-outdated');
+  }
+
+  const dismissed = localStorage.getItem(`dismissed-version-${latestSha}`);
+  if (dismissed) {
+    return;
+  }
+  if (currentDate < latestDate) {
+    showUpdateBanner(latestDateStr, latestSha);
+  }
+}
+
+export async function fetchVersion() {
+  const appVersion = document.getElementById('appVersion');
+  if (!appVersion) {
+    return;
+  }
+
+  // Check cache
+  try {
+    const cached = sessionStorage.getItem(CACHE_KEYS.VERSION_INFO);
+    if (cached) {
+      const { data, timestamp } = JSON.parse(cached);
+      // Check if cache is fresh (less than 15 minutes old)
+      if (Date.now() - timestamp < CACHE_DURATIONS.versionCheck) {
+        processVersionData(data, appVersion);
+        return;
+      }
+    }
+  } catch (e) {
+    console.warn('Failed to parse version cache', e);
+  }
+
+  try {
+    const latestData = await fetchJSON(`https://api.github.com/repos/${OWNER}/${REPO}/commits/${BRANCH}`);
+    if (!latestData) {
+      console.warn('Version check: GitHub API request failed (possibly rate limited)');
+      if (appVersion) {
+        appVersion.textContent = 'version check rate limited';
+        appVersion.classList.add('version-badge');
+      }
+      return;
+    }
+
+    // Cache result
+    try {
+      sessionStorage.setItem(CACHE_KEYS.VERSION_INFO, JSON.stringify({
+        data: latestData,
+        timestamp: Date.now()
+      }));
+    } catch (e) {
+      console.warn('Failed to cache version info', e);
+    }
+
+    processVersionData(latestData, appVersion);
+
+  } catch (error) {
+    if (appVersion) {
+      appVersion.textContent = 'version unavailable';
+    }
+  }
+}

--- a/src/shared-init.js
+++ b/src/shared-init.js
@@ -9,7 +9,7 @@ import { parseParams } from './utils/url-params.js';
 import statusBar from './modules/status-bar.js';
 import { getFirebaseReady } from './firebase-init.js';
 import { waitForDOMReady } from './utils/dom-helpers.js';
-import { fetchJSON } from './modules/github-api.js';
+import { fetchVersion } from './modules/version-check.js';
 
 let isInitialized = false;
 
@@ -20,105 +20,6 @@ async function waitForFirebase() {
     console.error('Firebase initialization failed:', error);
     statusBar.showMessage(ERRORS.FIREBASE_NOT_READY, 'error');
     throw error;
-  }
-}
-
-function showUpdateBanner(latestDate, latestSha) {
-  if (document.getElementById('updateBanner')) return;
-
-  const banner = document.createElement('div');
-  banner.id = 'updateBanner';
-  banner.classList.add('update-banner');
-
-  const message = document.createElement('span');
-  message.textContent = `Update available: v${latestDate} (${latestSha})`;
-  message.classList.add('update-banner__message');
-
-  const buttonContainer = document.createElement('div');
-  buttonContainer.classList.add('update-banner__actions');
-
-  const refreshButton = document.createElement('button');
-  refreshButton.textContent = 'Refresh';
-  refreshButton.classList.add('update-banner__button');
-  refreshButton.addEventListener('click', () => {
-    window.location.reload();
-  });
-
-  const dismissButton = document.createElement('button');
-  dismissButton.textContent = '×';
-  dismissButton.classList.add('update-banner__dismiss');
-  dismissButton.addEventListener('click', () => {
-    localStorage.setItem(`dismissed-version-${latestSha}`, 'true');
-    banner.remove();
-    document.body.classList.remove('has-version-banner');
-  });
-
-  buttonContainer.appendChild(refreshButton);
-  buttonContainer.appendChild(dismissButton);
-
-  banner.appendChild(message);
-  banner.appendChild(buttonContainer);
-
-  document.body.insertBefore(banner, document.body.firstChild);
-
-  document.body.classList.add('has-version-banner');
-}
-
-async function fetchVersion() {
-  const appVersion = document.getElementById('appVersion');
-  if (!appVersion) {
-    return;
-  }
-  
-  try {
-    const latestData = await fetchJSON(`https://api.github.com/repos/${OWNER}/${REPO}/commits/${BRANCH}`);
-    if (!latestData) {
-      console.warn('Version check: GitHub API request failed (possibly rate limited)');
-      if (appVersion) {
-        appVersion.textContent = 'version check rate limited';
-        appVersion.classList.add('version-badge');
-      }
-      return;
-    }
-    const latestSha = latestData.sha.substring(0, 7);
-    const latestDate = new Date(latestData.commit.committer.date);
-    const latestDateStr = latestDate.toLocaleDateString('en-CA'); // YYYY-MM-DD
-    
-    const currentVersionMeta = document.querySelector('meta[name="app-version"]');
-    let currentDate = latestDate;
-    let currentSha = latestSha;
-    let currentDateStr = latestDateStr;
-    if (currentVersionMeta) {
-      const versionContent = currentVersionMeta.content; // Format: "sha|date"
-      const [metaSha, metaDate] = versionContent.split('|');
-      if (metaSha && metaDate) {
-        currentSha = metaSha;
-        currentDate = new Date(metaDate);
-        currentDateStr = new Date(metaDate).toLocaleDateString('en-CA');
-      }
-    }
-
-    if (currentDate < latestDate) {
-      appVersion.textContent = `v${currentDateStr} (${currentSha})`;
-      appVersion.classList.add('version-badge', 'status-outdated');
-    } else {
-      appVersion.textContent = `v${latestDateStr} (${latestSha})`;
-      appVersion.classList.add('version-badge');
-      appVersion.classList.remove('status-outdated');
-    }
-    
-    const dismissed = localStorage.getItem(`dismissed-version-${latestSha}`);
-    if (dismissed) {
-      return;
-    }
-    if (currentDate < latestDate) {
-      showUpdateBanner(latestDateStr, latestSha);
-    }
-    
-  } catch (error) {
-    if (appVersion) {
-      appVersion.textContent = 'version unavailable';
-    }
   }
 }
 

--- a/src/tests/modules/version-check.test.js
+++ b/src/tests/modules/version-check.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchVersion } from '../../modules/version-check.js';
+import * as githubApi from '../../modules/github-api.js';
+import { CACHE_KEYS, CACHE_DURATIONS } from '../../utils/constants.js';
+
+// Mock dependencies
+vi.mock('../../modules/github-api.js', () => ({
+  fetchJSON: vi.fn(),
+}));
+
+describe('version-check', () => {
+  let appVersionMock;
+  let updateBannerMock;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Mock DOM
+    appVersionMock = {
+      textContent: '',
+      classList: {
+        add: vi.fn(),
+        remove: vi.fn(),
+      },
+    };
+
+    document.getElementById = vi.fn((id) => {
+      if (id === 'appVersion') return appVersionMock;
+      if (id === 'updateBanner') return updateBannerMock; // usually null initially
+      return null;
+    });
+
+    document.querySelector = vi.fn((selector) => {
+      if (selector === 'meta[name="app-version"]') {
+        return { content: 'sha|2023-01-01' };
+      }
+      return null;
+    });
+
+    document.createElement = vi.fn(() => ({
+      classList: { add: vi.fn() },
+      addEventListener: vi.fn(),
+      remove: vi.fn(),
+      appendChild: vi.fn(),
+    }));
+
+    vi.spyOn(document.body, 'insertBefore').mockImplementation(() => {});
+    vi.spyOn(document.body.classList, 'add');
+    vi.spyOn(document.body.classList, 'remove');
+
+    // Mock Storage
+    const storageMock = (() => {
+      let store = {};
+      return {
+        getItem: vi.fn((key) => store[key] || null),
+        setItem: vi.fn((key, value) => { store[key] = value.toString(); }),
+        clear: vi.fn(() => { store = {}; }),
+        removeItem: vi.fn((key) => { delete store[key]; }),
+      };
+    })();
+
+    Object.defineProperty(window, 'sessionStorage', { value: storageMock, writable: true });
+    Object.defineProperty(window, 'localStorage', { value: storageMock, writable: true });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should use cached data if fresh', async () => {
+    // Make current version match fresh data so appVersion text updates to it
+    document.querySelector.mockImplementation((s) => {
+        if (s === 'meta[name="app-version"]') return { content: 'abcdef|2023-10-27T10:00:00Z' };
+        return null;
+    });
+
+    const freshData = {
+      data: { sha: 'abcdef', commit: { committer: { date: '2023-10-27T10:00:00Z' } } },
+      timestamp: Date.now() - 1000 // 1 sec old
+    };
+    sessionStorage.setItem(CACHE_KEYS.VERSION_INFO, JSON.stringify(freshData));
+
+    await fetchVersion();
+
+    expect(githubApi.fetchJSON).not.toHaveBeenCalled();
+    expect(appVersionMock.textContent).toContain('v2023-10-27 (abcdef)');
+  });
+
+  it('should fetch from API if cache is missing', async () => {
+    document.querySelector.mockImplementation((s) => {
+        if (s === 'meta[name="app-version"]') return { content: '1234567|2023-10-28T10:00:00Z' };
+        return null;
+    });
+
+    sessionStorage.getItem.mockReturnValue(null);
+    const apiData = { sha: '1234567', commit: { committer: { date: '2023-10-28T10:00:00Z' } } };
+    githubApi.fetchJSON.mockResolvedValue(apiData);
+
+    await fetchVersion();
+
+    expect(githubApi.fetchJSON).toHaveBeenCalled();
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      CACHE_KEYS.VERSION_INFO,
+      expect.stringContaining('"sha":"1234567"')
+    );
+    expect(appVersionMock.textContent).toContain('v2023-10-28 (1234567)');
+  });
+
+  it('should fetch from API if cache is stale', async () => {
+    document.querySelector.mockImplementation((s) => {
+        if (s === 'meta[name="app-version"]') return { content: 'newsha|2023-10-28T10:00:00Z' };
+        return null;
+    });
+
+    const staleData = {
+      data: { sha: 'oldsha', commit: { committer: { date: '2020-01-01' } } },
+      timestamp: Date.now() - (CACHE_DURATIONS.versionCheck + 1000)
+    };
+    sessionStorage.setItem(CACHE_KEYS.VERSION_INFO, JSON.stringify(staleData));
+
+    const apiData = { sha: 'newsha', commit: { committer: { date: '2023-10-28T10:00:00Z' } } };
+    githubApi.fetchJSON.mockResolvedValue(apiData);
+
+    await fetchVersion();
+
+    expect(githubApi.fetchJSON).toHaveBeenCalled();
+    expect(appVersionMock.textContent).toContain('v2023-10-28 (newsha)');
+  });
+
+  it('should handle rate limiting (API returns null)', async () => {
+    githubApi.fetchJSON.mockResolvedValue(null);
+
+    await fetchVersion();
+
+    expect(appVersionMock.textContent).toBe('version check rate limited');
+    expect(appVersionMock.classList.add).toHaveBeenCalledWith('version-badge');
+  });
+
+  it('should handle API errors', async () => {
+    githubApi.fetchJSON.mockRejectedValue(new Error('Network error'));
+
+    await fetchVersion();
+
+    expect(appVersionMock.textContent).toBe('version unavailable');
+  });
+
+  it('should show update banner if new version available', async () => {
+    const apiData = { sha: 'newsha', commit: { committer: { date: '2099-01-01T10:00:00Z' } } }; // Future date
+    githubApi.fetchJSON.mockResolvedValue(apiData);
+
+    await fetchVersion();
+
+    expect(document.body.insertBefore).toHaveBeenCalled();
+    expect(document.body.classList.add).toHaveBeenCalledWith('has-version-banner');
+  });
+
+  it('should NOT show update banner if new version NOT available', async () => {
+    const apiData = { sha: 'sha', commit: { committer: { date: '2023-01-01T00:00:00Z' } } }; // Same as current mocked meta
+    githubApi.fetchJSON.mockResolvedValue(apiData);
+
+    await fetchVersion();
+
+    expect(document.body.insertBefore).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -62,6 +62,10 @@ export const STORAGE_KEYS = {
   showUserBranches: "showUserBranches"
 };
 
+export const CACHE_KEYS = {
+  VERSION_INFO: 'version_info'
+};
+
 // Error messages
 export const ERRORS = {
   FIREBASE_NOT_READY: "Firebase not initialized. Please refresh.",
@@ -326,5 +330,6 @@ export const PAGE_SIZES = {
  */
 export const CACHE_DURATIONS = {
   short: 300000, // 5 minutes
-  session: 0
+  session: 0,
+  versionCheck: 900000 // 15 minutes
 };


### PR DESCRIPTION
- Define CACHE_KEYS.VERSION_INFO and CACHE_DURATIONS.versionCheck in constants.js
- Extract version check logic to new module `src/modules/version-check.js`
- Implement 15-minute caching strategy using sessionStorage
- Handle API rate limiting and errors gracefully
- Refactor `src/shared-init.js` to use the new module
- Add unit tests for version check logic and caching behavior

---
https://jules.google.com/session/10017776975679506474