### PR TITLE
migrated user branches out of runtime constants (fixes #556)

### DIFF
--- a/src/tests/utils/constants.test.js
+++ b/src/tests/utils/constants.test.js
@@ -151,10 +151,6 @@ describe('constants', () => {
   });
 
   describe('branch classification', () => {
-    it('should define user branches', () => {
-      expect(constants.USER_BRANCHES).toEqual(['dogi', 'jesse', 'saksham']);
-    });
-
     it('should define feature patterns', () => {
       expect(constants.FEATURE_PATTERNS).toEqual([
         'codex/', 'feature/', 'fix/', 'bugfix/', 'hotfix/'

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -22,9 +22,6 @@ export const STORAGE_KEY_FAVORITE_REPOS = "jules_favorite_repos";
 // Hardcoded favorite branches (always favorites for all users)
 export const HARDCODED_FAVORITE_BRANCHES = ["main", "web-captures"];
 
-// User branches (branch names representing individual users)
-export const USER_BRANCHES = ['dogi', 'jesse', 'saksham'];
-
 export const STORAGE_KEY_FAVORITE_BRANCHES = "favorite_branches";
 
 // Tag definitions


### PR DESCRIPTION
Test-specific mock data shouldn't live in production constants where it unnecessarily bloats the application bundle and can be accidentally used at runtime.

