### PR TITLE
deadcode: PRETTY_TITLES in constants.js

### DIFF
--- a/src/tests/utils/constants.test.js
+++ b/src/tests/utils/constants.test.js
@@ -7,7 +7,6 @@ describe('constants', () => {
       expect(constants.OWNER).toBe('promptroot');
       expect(constants.REPO).toBe('promptroot');
       expect(constants.BRANCH).toBe('main');
-      expect(constants.PRETTY_TITLES).toBe(true);
     });
 
     it('should export Jules API configuration', () => {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -5,7 +5,6 @@ import { ICONS, createIconWithText } from './icon-helpers.js';
 export const OWNER = "promptroot";
 export const REPO = "promptroot";
 export const BRANCH = "main";
-export const PRETTY_TITLES = true;
 
 // GitHub API
 export const GIST_POINTER_REGEX = /^https:\/\/gist\.githubusercontent\.com\/\S+\/raw\/\S+$/i;


### PR DESCRIPTION
Removed dead code constant PRETTY_TITLES (never imported/used at runtime) while retaining [OWNER](vscode-file://vscode-app/c:/Users/jesse/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [REPO](vscode-file://vscode-app/c:/Users/jesse/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [BRANCH](vscode-file://vscode-app/c:/Users/jesse/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which are actively used as default repository configuration in [shared-init.js:78](vscode-file://vscode-app/c:/Users/jesse/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [app.js:11-13](vscode-file://vscode-app/c:/Users/jesse/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).