### PR TITLE
Migrate from global Firebase to service imports

### DIFF
--- a/src/firebase-init.js
+++ b/src/firebase-init.js
@@ -29,23 +29,6 @@ function initFirebaseWhenReady() {
       // Initialize services module
       initServices(auth, db, null);
 
-      // Backward compatibility with deprecation warnings
-      Object.defineProperty(window, 'auth', {
-        get: () => {
-          console.warn('DEPRECATED: window.auth is deprecated. Use getAuth() from modules/firebase-service.js');
-          return auth;
-        },
-        configurable: true
-      });
-
-      Object.defineProperty(window, 'db', {
-        get: () => {
-          console.warn('DEPRECATED: window.db is deprecated. Use getDb() from modules/firebase-service.js');
-          return db;
-        },
-        configurable: true
-      });
-
       // Functions removed - not used in this app (uses direct REST API calls)
       
       // Port 5000 = dev server with emulators, port 3000 = production

--- a/src/modules/branch-selector.js
+++ b/src/modules/branch-selector.js
@@ -3,6 +3,7 @@ import { getBranches } from './github-api.js';
 import { getCache, setCache, CACHE_KEYS } from '../utils/session-cache.js';
 import { initDropdown } from './dropdown.js';
 import { getCurrentUser } from './auth.js';
+import { getDb } from './firebase-service.js';
 
 let branchSelect = null;
 let branchDropdownBtn = null;
@@ -99,13 +100,14 @@ export function getCurrentRepo() {
  */
 async function loadFavoriteBranches() {
   const user = getCurrentUser();
-  if (!user || !window.db) {
+  const db = getDb();
+  if (!user || !db) {
     favoriteBranches = [...HARDCODED_FAVORITE_BRANCHES];
     return;
   }
 
   try {
-    const doc = await window.db.collection('users').doc(user.uid).get();
+    const doc = await db.collection('users').doc(user.uid).get();
     if (doc.exists && doc.data().favoriteBranches) {
       // Merge user favorites with hardcoded favorites
       const userFavorites = doc.data().favoriteBranches || [];
@@ -124,7 +126,8 @@ async function loadFavoriteBranches() {
  */
 async function saveFavoriteBranches(newFavorites) {
   const user = getCurrentUser();
-  if (!user || !window.db) {
+  const db = getDb();
+  if (!user || !db) {
     return;
   }
 
@@ -132,7 +135,7 @@ async function saveFavoriteBranches(newFavorites) {
     // Filter out hardcoded favorites before saving (they're always included)
     const userFavorites = newFavorites.filter(b => !HARDCODED_FAVORITE_BRANCHES.includes(b));
     
-    await window.db.collection('users').doc(user.uid).set({
+    await db.collection('users').doc(user.uid).set({
       favoriteBranches: userFavorites
     }, { merge: true });
     

--- a/src/modules/github-api.js
+++ b/src/modules/github-api.js
@@ -1,4 +1,5 @@
 import { GIST_POINTER_REGEX, GIST_URL_REGEX, CACHE_DURATIONS } from '../utils/constants.js';
+import { getAuth } from './firebase-service.js';
 
 let viaProxy = (url) => url;
 
@@ -82,7 +83,8 @@ const TOKEN_MAX_AGE = 60 * 24 * 60 * 60 * 1000; // 60 days
 
 async function getGitHubAccessToken() {
   try {
-    const user = window.auth?.currentUser;
+    const auth = getAuth();
+    const user = auth?.currentUser;
     if (!user) return null;
 
     const isGitHubAuth = user.providerData.some(p => p.providerId === 'github.com');

--- a/src/modules/jules-account.js
+++ b/src/modules/jules-account.js
@@ -13,13 +13,15 @@ import { attachPromptViewerHandlers } from './prompt-viewer.js';
 import { TIMEOUTS, JULES_UI_TEXT, CSS_CLASSES } from '../utils/constants.js';
 import { renderStatus, STATUS_TYPES } from './status-renderer.js';
 import { toggleVisibility } from '../utils/dom-helpers.js';
+import { getAuth } from './firebase-service.js';
 
 let allSessionsCache = [];
 let sessionNextPageToken = null;
 
 export function showUserProfileModal() {
   const modal = document.getElementById('userProfileModal');
-  const user = window.auth?.currentUser;
+  const auth = getAuth();
+  const user = auth?.currentUser;
 
   if (!user) {
     handleError('Not logged in.', { source: 'showUserProfileModal' }, { category: ErrorCategory.AUTH });
@@ -151,7 +153,8 @@ export function showUserProfileModal() {
   
   if (sessionSearchInput) {
     sessionSearchInput.addEventListener('input', () => {
-      const user = window.auth?.currentUser;
+      const auth = getAuth();
+      const user = auth?.currentUser;
       if (!user) return;
       renderAllSessions(allSessionsCache);
     });
@@ -526,7 +529,8 @@ export function hideJulesSessionsHistoryModal() {
 }
 
 async function loadSessionsPage() {
-  const user = window.auth?.currentUser;
+  const auth = getAuth();
+  const user = auth?.currentUser;
   if (!user) return;
   
   const allSessionsList = document.getElementById('allSessionsList');

--- a/src/modules/jules-api.js
+++ b/src/modules/jules-api.js
@@ -4,6 +4,7 @@
 import { JULES_API_BASE, ERRORS, PAGE_SIZES, JULES_MESSAGES, TIMEOUTS } from '../utils/constants.js';
 import { showToast } from './toast.js';
 import { handleError, ErrorCategory } from '../utils/error-handler.js';
+import { getAuth, getDb } from './firebase-service.js';
 
 // API key cache for memoization
 const keyCache = new Map();
@@ -28,11 +29,12 @@ export async function getDecryptedJulesKey(uid) {
   }
 
   try {
-    if (!window.db) {
+    const db = getDb();
+    if (!db) {
       return null;
     }
 
-    const doc = await window.db.collection('julesKeys').doc(uid).get();
+    const doc = await db.collection('julesKeys').doc(uid).get();
     if (!doc.exists) {
       return null;
     }
@@ -216,7 +218,8 @@ export async function loadJulesProfileInfo(uid) {
 }
 
 export async function callRunJulesFunction(promptText, sourceId, branch = 'master', title = '') {
-  const user = window.auth ? window.auth.currentUser : null;
+  const auth = getAuth();
+  const user = auth ? auth.currentUser : null;
   if (!user) {
     handleError(JULES_MESSAGES.NOT_LOGGED_IN, { source: 'callRunJulesFunction' }, { category: ErrorCategory.AUTH });
     return null;
@@ -282,7 +285,8 @@ async function runJulesAPI(promptText, sourceId, branch, title, user) {
 
 export async function handleTryInJules(promptText) {
   try {
-    const user = window.auth ? window.auth.currentUser : null;
+    const auth = getAuth();
+    const user = auth ? auth.currentUser : null;
     if (!user) {
       try {
         const { signInWithGitHub } = await import('./auth.js');
@@ -300,7 +304,8 @@ export async function handleTryInJules(promptText) {
 }
 
 export async function handleTryInJulesAfterAuth(promptText) {
-  const user = window.auth ? window.auth.currentUser : null;
+  const auth = getAuth();
+  const user = auth ? auth.currentUser : null;
   if (!user) {
     handleError(JULES_MESSAGES.NOT_LOGGED_IN, { source: 'handleTryInJulesAfterAuth' }, { category: ErrorCategory.AUTH });
     return;

--- a/src/modules/jules-free-input.js
+++ b/src/modules/jules-free-input.js
@@ -1,4 +1,5 @@
 import { getCurrentUser } from './auth.js';
+import { getAuth } from './firebase-service.js';
 import { RepoSelector, BranchSelector } from './repo-branch-selector.js';
 import { showToast } from './toast.js';
 import { copyAndOpen } from './copen.js';
@@ -15,7 +16,8 @@ export function getLastSelectedSource() {
 }
 
 export function showFreeInputModal() {
-  const user = window.auth ? window.auth.currentUser : null;
+  const auth = getAuth();
+  const user = auth ? auth.currentUser : null;
   if (!user) {
     (async () => {
       try {
@@ -33,7 +35,8 @@ export function showFreeInputModal() {
 }
 
 export async function handleFreeInputAfterAuth() {
-  const user = window.auth ? window.auth.currentUser : null;
+  const auth = getAuth();
+  const user = auth ? auth.currentUser : null;
   if (!user) {
     showToast('Not logged in.', 'error');
     return;
@@ -352,7 +355,8 @@ export function showFreeInputForm() {
       return;
     }
 
-    const user = window.auth?.currentUser;
+    const auth = getAuth();
+    const user = auth?.currentUser;
     if (!user) {
       showToast('Please sign in to queue prompts.', 'warn');
       return;

--- a/src/modules/jules-keys.js
+++ b/src/modules/jules-keys.js
@@ -1,4 +1,5 @@
 import { getDoc, deleteDoc, setDoc, getServerTimestamp } from '../utils/firestore-helpers.js';
+import { getDb } from './firebase-service.js';
 
 // ===== Jules Key Management Module =====
 // Handles encryption, storage, and retrieval of Jules API keys
@@ -7,7 +8,8 @@ const CACHE_KEY = 'jules_key_data';
 
 export async function checkJulesKey(uid) {
   try {
-    if (!window.db) {
+    const db = getDb();
+    if (!db) {
       return false;
     }
     const doc = await getDoc('julesKeys', uid, CACHE_KEY);
@@ -19,7 +21,8 @@ export async function checkJulesKey(uid) {
 
 export async function deleteStoredJulesKey(uid) {
   try {
-    if (!window.db) return false;
+    const db = getDb();
+    if (!db) return false;
     await deleteDoc('julesKeys', uid, CACHE_KEY);
     return true;
   } catch (error) {
@@ -39,7 +42,8 @@ export async function encryptAndStoreKey(plaintext, uid) {
     const ciphertext = await window.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintextData);
     const encrypted = btoa(String.fromCharCode(...new Uint8Array(ciphertext)));
 
-    if (!window.db) throw new Error('Firestore not initialized');
+    const db = getDb();
+    if (!db) throw new Error('Firestore not initialized');
     await setDoc('julesKeys', uid, {
       key: encrypted,
       storedAt: getServerTimestamp()

--- a/src/modules/jules-modal.js
+++ b/src/modules/jules-modal.js
@@ -8,6 +8,7 @@ import { toggleVisibility } from '../utils/dom-helpers.js';
 import { extractTitleFromPrompt } from '../utils/title.js';
 import { RETRY_CONFIG, TIMEOUTS, JULES_MESSAGES } from '../utils/constants.js';
 import { showToast } from './toast.js';
+import { getAuth } from './firebase-service.js';
 
 let lastSelectedSourceId = 'sources/github/promptroot/promptroot';
 let lastSelectedBranch = 'main';
@@ -51,7 +52,8 @@ export function showJulesKeyModal(onSave) {
       saveBtn.textContent = 'Saving...';
       saveBtn.disabled = true;
 
-      const user = window.auth ? window.auth.currentUser : null;
+      const auth = getAuth();
+      const user = auth ? auth.currentUser : null;
       if (!user) {
         showToast('Not logged in.', 'error');
         saveBtn.textContent = 'Save & Continue';
@@ -142,7 +144,8 @@ export async function showJulesEnvModal(promptText) {
   queueBtn.onclick = async () => {
     if (!selectedSourceId || !selectedBranch) return;
     
-    const user = window.auth?.currentUser;
+    const auth = getAuth();
+    const user = auth?.currentUser;
     if (!user) {
       showToast(JULES_MESSAGES.SIGN_IN_REQUIRED, 'warn');
       return;
@@ -204,7 +207,8 @@ async function handleRepoSelect(sourceId, branch, promptText, suppressPopups = f
           showToast(JULES_MESSAGES.cancelled(0, 1), 'warn');
           return;
         } else if (result.action === 'queue') {
-          const user = window.auth?.currentUser;
+          const auth = getAuth();
+          const user = auth?.currentUser;
           if (!user) {
             showToast(JULES_MESSAGES.SIGN_IN_REQUIRED, 'warn');
             return;
@@ -237,7 +241,8 @@ async function handleRepoSelect(sourceId, branch, promptText, suppressPopups = f
           showToast(JULES_MESSAGES.cancelled(0, 1), 'warn');
           return;
         } else if (result.action === 'queue') {
-          const user = window.auth?.currentUser;
+          const auth = getAuth();
+          const user = auth?.currentUser;
           if (!user) {
             showToast(JULES_MESSAGES.SIGN_IN_REQUIRED, 'warn');
             return;

--- a/src/modules/jules-subtask-modal.js
+++ b/src/modules/jules-subtask-modal.js
@@ -13,6 +13,7 @@ import { showConfirm } from './confirm-modal.js';
 import { extractTitleFromPrompt } from '../utils/title.js';
 import statusBar from './status-bar.js';
 import { JULES_MESSAGES, TIMEOUTS, RETRY_CONFIG } from '../utils/constants.js';
+import { getAuth } from './firebase-service.js';
 
 // Module state
 let currentFullPrompt = '';
@@ -74,7 +75,8 @@ export function showSubtaskSplitModal(promptText) {
   };
 
   queueBtn.onclick = async () => {
-    const user = window.auth?.currentUser;
+    const auth = getAuth();
+    const user = auth?.currentUser;
     if (!user) {
       showToast(JULES_MESSAGES.SIGN_IN_REQUIRED_SUBTASKS, 'warn');
       return;
@@ -359,7 +361,8 @@ async function submitSubtasks(subtasks) {
   let skippedCount = 0;
   let successCount = 0;
   let paused = false;
-  const user = window.auth ? window.auth.currentUser : null;
+  const auth = getAuth();
+  const user = auth ? auth.currentUser : null;
 
   statusBar?.showMessage?.(`Processing ${totalCount} subtasks...`, { timeout: 0 });
   statusBar?.setAction?.('Pause', () => {
@@ -444,7 +447,8 @@ async function submitSubtasks(subtasks) {
             submitted = true;
             statusBar?.showMessage?.(`Skipped subtask. Continuing with remaining...`, { timeout: TIMEOUTS.actionFeedback });
           } else if (result.action === 'queue') {
-            const user = window.auth?.currentUser;
+            const auth = getAuth();
+            const user = auth?.currentUser;
             if (!user) {
               statusBar?.clear?.();
               showToast(JULES_MESSAGES.SIGN_IN_REQUIRED_SUBTASKS, 'warn');
@@ -486,7 +490,8 @@ async function submitSubtasks(subtasks) {
             return;
           } else {
             if (result.action === 'queue') {
-              const user = window.auth?.currentUser;
+              const auth = getAuth();
+              const user = auth?.currentUser;
               if (!user) {
                 statusBar?.clear?.();
                 showToast(JULES_MESSAGES.SIGN_IN_REQUIRED_SUBTASKS, 'warn');

--- a/src/modules/repo-branch-selector.js
+++ b/src/modules/repo-branch-selector.js
@@ -1,4 +1,6 @@
 import { getCurrentUser } from './auth.js';
+import { getDb } from './firebase-service.js';
+import { getArrayUnion, getArrayRemove } from '../utils/firestore-helpers.js';
 import { showToast } from './toast.js';
 import { toggleVisibility } from '../utils/dom-helpers.js';
 
@@ -79,8 +81,9 @@ export class RepoSelector {
     
     this.favorites = DEFAULT_FAVORITE_REPOS;
     try {
-      if (window.db) {
-        const doc = await window.db.collection('users').doc(user.uid).get();
+      const db = getDb();
+      if (db) {
+        const doc = await db.collection('users').doc(user.uid).get();
         if (doc.exists && doc.data().favoriteRepos) {
           this.favorites = doc.data().favoriteRepos;
         }
@@ -413,8 +416,9 @@ export class RepoSelector {
   async saveFavorites(newFavorites) {
     const user = getCurrentUser();
     try {
-      if (window.db) {
-        await window.db.collection('users').doc(user.uid).set({
+      const db = getDb();
+      if (db) {
+        await db.collection('users').doc(user.uid).set({
           favoriteRepos: newFavorites
         }, { merge: true });
         this.favorites = newFavorites;
@@ -429,9 +433,10 @@ export class RepoSelector {
     const newFavorite = { id: sourceId, name, branch };
     
     try {
-      if (window.db) {
-        await window.db.collection('users').doc(user.uid).set({
-          favoriteRepos: window.firebase.firestore.FieldValue.arrayUnion(newFavorite)
+      const db = getDb();
+      if (db) {
+        await db.collection('users').doc(user.uid).set({
+          favoriteRepos: getArrayUnion(newFavorite)
         }, { merge: true });
         this.favorites = [...this.favorites, newFavorite];
       }
@@ -447,9 +452,10 @@ export class RepoSelector {
     if (!favoriteToRemove) return;
     
     try {
-      if (window.db) {
-        await window.db.collection('users').doc(user.uid).set({
-          favoriteRepos: window.firebase.firestore.FieldValue.arrayRemove(favoriteToRemove)
+      const db = getDb();
+      if (db) {
+        await db.collection('users').doc(user.uid).set({
+          favoriteRepos: getArrayRemove(favoriteToRemove)
         }, { merge: true });
         this.favorites = this.favorites.filter(f => f.id !== sourceId);
       }

--- a/src/pages/jules-page.js
+++ b/src/pages/jules-page.js
@@ -4,6 +4,7 @@
  */
 
 import { waitForFirebase } from '../shared-init.js';
+import { getAuth } from '../modules/firebase-service.js';
 import { loadJulesAccountInfo } from '../modules/jules-account.js';
 import { showJulesKeyModal } from '../modules/jules-modal.js';
 import { deleteStoredJulesKey, checkJulesKey } from '../modules/jules-keys.js';
@@ -21,7 +22,8 @@ function waitForComponents() {
 }
 
 async function loadJulesInfo() {
-  const user = window.auth?.currentUser;
+  const auth = getAuth();
+  const user = auth?.currentUser;
   
   const loadingDiv = document.getElementById('julesLoading');
   const notSignedInDiv = document.getElementById('julesNotSignedIn');
@@ -87,7 +89,8 @@ async function initApp() {
   const addKeyHandler = () => {
     showJulesKeyModal(() => {
       // Reload Jules info after saving key
-      const user = window.auth?.currentUser;
+      const auth = getAuth();
+      const user = auth?.currentUser;
       if (user) {
         loadJulesInfo();
       }
@@ -108,7 +111,8 @@ async function initApp() {
       if (!confirmed) return;
       
       try {
-        const user = window.auth?.currentUser;
+        const auth = getAuth();
+        const user = auth?.currentUser;
         if (!user) return;
         
         resetJulesKeyBtn.disabled = true;
@@ -155,7 +159,8 @@ async function initApp() {
   const loadJulesInfoBtn = document.getElementById('loadJulesInfoBtn');
   if (loadJulesInfoBtn) {
     loadJulesInfoBtn.onclick = () => {
-      const user = window.auth?.currentUser;
+      const auth = getAuth();
+      const user = auth?.currentUser;
       if (user) {
         loadJulesInfo();
       }
@@ -164,7 +169,7 @@ async function initApp() {
 
   try {
     await waitForFirebase();
-    window.auth.onAuthStateChanged((user) => {
+    getAuth().onAuthStateChanged((user) => {
       if (user) {
         loadJulesInfo();
       } else {

--- a/src/pages/profile-page.js
+++ b/src/pages/profile-page.js
@@ -4,6 +4,7 @@
  */
 
 import { waitForFirebase } from '../shared-init.js';
+import { getAuth } from '../modules/firebase-service.js';
 import { loadProfileDirectly } from '../modules/jules-account.js';
 import { TIMEOUTS } from '../utils/constants.js';
 
@@ -16,7 +17,8 @@ function waitForComponents() {
 }
 
 async function loadProfile() {
-  const user = window.auth?.currentUser;
+  const auth = getAuth();
+  const user = auth?.currentUser;
   
   if (!user) {
     const profileUserName = document.getElementById('profileUserName');
@@ -36,7 +38,7 @@ async function loadProfile() {
 async function initApp() {
   try {
     await waitForFirebase();
-    window.auth.onAuthStateChanged((user) => {
+    getAuth().onAuthStateChanged((user) => {
       if (user) {
         loadProfile();
       } else {

--- a/src/pages/queue-page.js
+++ b/src/pages/queue-page.js
@@ -7,6 +7,7 @@ import { initMutualExclusivity } from '../utils/checkbox-helpers.js';
 import { attachQueueHandlers, listJulesQueue, renderQueueListDirectly } from '../modules/jules-queue.js';
 import { createElement, clearElement, waitForDOMReady, waitForHeader } from '../utils/dom-helpers.js';
 import { handleError } from '../utils/error-handler.js';
+import { getAuth } from '../modules/firebase-service.js';
 
 // Initialize checkbox mutual exclusivity
 initMutualExclusivity();
@@ -24,7 +25,8 @@ function initApp() {
   // Initialize queue functionality
   attachQueueHandlers();
   
-  const user = window.auth?.currentUser;
+  const auth = getAuth();
+  const user = auth?.currentUser;
   if (user) {
     document.getElementById('queueLoading').classList.remove('hidden');
     document.getElementById('queueControls').classList.add('hidden');
@@ -37,7 +39,7 @@ function initApp() {
   }
   
   // Listen for auth state changes
-  window.auth.onAuthStateChanged((user) => {
+  auth.onAuthStateChanged((user) => {
     if (user) {
       document.getElementById('queueLoading').classList.remove('hidden');
       document.getElementById('queueControls').classList.add('hidden');
@@ -52,7 +54,8 @@ function initApp() {
 }
 
 async function loadQueue() {
-  const user = window.auth?.currentUser;
+  const auth = getAuth();
+  const user = auth?.currentUser;
   const listDiv = document.getElementById('allQueueList');
   const loadingDiv = document.getElementById('queueLoading');
   const controlsDiv = document.getElementById('queueControls');

--- a/src/pages/sessions-page.js
+++ b/src/pages/sessions-page.js
@@ -1,4 +1,5 @@
 import { waitForFirebase } from '../shared-init.js';
+import { getAuth } from '../modules/firebase-service.js';
 import { listJulesSessions, getDecryptedJulesKey } from '../modules/jules-api.js';
 import { attachPromptViewerHandlers } from '../modules/prompt-viewer.js';
 import { debounce } from '../utils/debounce.js';
@@ -21,7 +22,8 @@ function waitForComponents() {
 }
 
 async function loadSessionsPage() {
-  const user = window.auth?.currentUser;
+  const auth = getAuth();
+  const user = auth?.currentUser;
   if (!user) return;
   
   const allSessionsList = document.getElementById('allSessionsList');
@@ -146,7 +148,8 @@ async function renderAllSessions(sessions) {
 
 async function loadSessions() {
   if (isSessionsLoading) return;
-  const user = window.auth?.currentUser;
+  const auth = getAuth();
+  const user = auth?.currentUser;
   
   const loadingDiv = document.getElementById('sessionsLoading');
   const notSignedInDiv = document.getElementById('sessionsNotSignedIn');
@@ -223,8 +226,9 @@ async function initApp() {
       loadMoreBtn.addEventListener('click', loadSessionsPage);
     }
 
-    if (window.auth && typeof window.auth.onAuthStateChanged === 'function') {
-      window.auth.onAuthStateChanged(() => {
+    const auth = getAuth();
+    if (auth && typeof auth.onAuthStateChanged === 'function') {
+      auth.onAuthStateChanged(() => {
         loadSessions();
       });
     }

--- a/src/tests/integration/prompt-loading.test.js
+++ b/src/tests/integration/prompt-loading.test.js
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fetchJSON, listPromptsViaContents } from '../../modules/github-api.js';
 
+vi.mock('../../modules/firebase-service.js', () => ({
+  getAuth: vi.fn(() => global.window.auth),
+  getDb: vi.fn(() => global.window.db),
+  onFirebaseReady: vi.fn((cb) => cb()),
+}));
+
 describe('GitHub API Module', () => {
     beforeEach(() => {
         global.fetch = vi.fn();

--- a/src/tests/modules/github-api.test.js
+++ b/src/tests/modules/github-api.test.js
@@ -15,6 +15,13 @@ import {
   clearCaches
 } from '../../modules/github-api.js';
 
+// Mock firebase service
+vi.mock('../../modules/firebase-service.js', () => ({
+  getAuth: vi.fn(() => global.window.auth),
+  getDb: vi.fn(() => global.window.db),
+  onFirebaseReady: vi.fn((cb) => cb()),
+}));
+
 // Mock global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;

--- a/src/tests/modules/jules-api.test.js
+++ b/src/tests/modules/jules-api.test.js
@@ -8,6 +8,13 @@ import {
   handleTryInJules
 } from '../../modules/jules-api.js';
 
+// Mock firebase service
+vi.mock('../../modules/firebase-service.js', () => ({
+  getAuth: vi.fn(() => global.window.auth),
+  getDb: vi.fn(() => global.window.db),
+  onFirebaseReady: vi.fn((cb) => cb()),
+}));
+
 // Mock global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;

--- a/src/tests/modules/jules-modal.test.js
+++ b/src/tests/modules/jules-modal.test.js
@@ -8,6 +8,13 @@ import {
   hideSubtaskErrorModal
 } from '../../modules/jules-modal.js';
 
+// Mock firebase service
+vi.mock('../../modules/firebase-service.js', () => ({
+  getAuth: vi.fn(() => global.window.auth),
+  getDb: vi.fn(() => global.window.db),
+  onFirebaseReady: vi.fn((cb) => cb()),
+}));
+
 // Mock dependencies
 vi.mock('../../modules/jules-keys.js', () => ({
   encryptAndStoreKey: vi.fn()

--- a/src/tests/modules/jules-queue.test.js
+++ b/src/tests/modules/jules-queue.test.js
@@ -13,6 +13,12 @@ import {
 import { getCache } from '../../utils/session-cache.js';
 
 // Mock dependencies
+vi.mock('../../modules/firebase-service.js', () => ({
+  getAuth: vi.fn(() => global.window.auth),
+  getDb: vi.fn(() => global.window.db),
+  onFirebaseReady: vi.fn((cb) => cb()),
+}));
+
 vi.mock('../../utils/title.js', () => ({
   extractTitleFromPrompt: vi.fn()
 }));

--- a/src/tests/modules/repo-branch-selector.test.js
+++ b/src/tests/modules/repo-branch-selector.test.js
@@ -2,6 +2,17 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { RepoSelector, BranchSelector } from '../../modules/repo-branch-selector.js';
 
 // Mock dependencies
+vi.mock('../../modules/firebase-service.js', () => ({
+  getAuth: vi.fn(() => global.window.auth),
+  getDb: vi.fn(() => global.window.db),
+  onFirebaseReady: vi.fn((cb) => cb()),
+}));
+
+vi.mock('../../utils/firestore-helpers.js', () => ({
+  getArrayUnion: vi.fn((val) => ({ arrayUnion: val })),
+  getArrayRemove: vi.fn((val) => ({ arrayRemove: val })),
+}));
+
 vi.mock('../../utils/dom-helpers.js', () => ({
   toggleVisibility: vi.fn()
 }));

--- a/src/tests/utils/firestore-helpers.test.js
+++ b/src/tests/utils/firestore-helpers.test.js
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getDoc, queryCollection, setDoc, updateDoc, deleteDoc, addDoc, retryOperation } from '../../utils/firestore-helpers.js';
 import * as sessionCache from '../../utils/session-cache.js';
 
+vi.mock('../../modules/firebase-service.js', () => ({
+  getAuth: vi.fn(() => global.window.auth),
+  getDb: vi.fn(() => global.window.db),
+  onFirebaseReady: vi.fn((cb) => cb()),
+}));
+
 vi.mock('../../utils/session-cache.js', () => ({
   getCache: vi.fn(),
   setCache: vi.fn(),

--- a/src/utils/firestore-helpers.js
+++ b/src/utils/firestore-helpers.js
@@ -1,4 +1,5 @@
 import { getCache, setCache, clearCache } from './session-cache.js';
+import { getAuth, getDb } from '../modules/firebase-service.js';
 
 /**
  * Retry an asynchronous operation with exponential backoff
@@ -32,8 +33,9 @@ export async function retryOperation(operation, maxRetries = 3, baseDelay = 1000
  */
 function getCollectionRef(collectionOrRef) {
   if (typeof collectionOrRef === 'string') {
-    if (!window.db) throw new Error('Firestore not initialized');
-    return window.db.collection(collectionOrRef);
+    const db = getDb();
+    if (!db) throw new Error('Firestore not initialized');
+    return db.collection(collectionOrRef);
   }
   return collectionOrRef;
 }
@@ -43,7 +45,8 @@ function getCollectionRef(collectionOrRef) {
  * @returns {string|null}
  */
 function getCurrentUserId() {
-  return window.auth?.currentUser?.uid || null;
+  const auth = getAuth();
+  return auth?.currentUser?.uid || null;
 }
 
 /**
@@ -278,4 +281,30 @@ export function getFieldDelete() {
       throw new Error('Firebase not initialized');
   }
   return fb.firestore.FieldValue.delete();
+}
+
+/**
+ * Get an array union field value
+ * @param {...any} elements - Elements to add to the array
+ * @returns {Object} - Firestore array union value
+ */
+export function getArrayUnion(...elements) {
+  const fb = window.firebase || (typeof firebase !== 'undefined' ? firebase : null);
+  if (!fb || !fb.firestore) {
+      throw new Error('Firebase not initialized');
+  }
+  return fb.firestore.FieldValue.arrayUnion(...elements);
+}
+
+/**
+ * Get an array remove field value
+ * @param {...any} elements - Elements to remove from the array
+ * @returns {Object} - Firestore array remove value
+ */
+export function getArrayRemove(...elements) {
+  const fb = window.firebase || (typeof firebase !== 'undefined' ? firebase : null);
+  if (!fb || !fb.firestore) {
+      throw new Error('Firebase not initialized');
+  }
+  return fb.firestore.FieldValue.arrayRemove(...elements);
 }


### PR DESCRIPTION
Migrated the codebase to use `getAuth()` and `getDb()` from `src/modules/firebase-service.js` instead of global `window.auth` and `window.db`. Updated `src/utils/firestore-helpers.js` to include array operations helper functions. Removed global property definitions from `src/firebase-init.js`. Updated all relevant tests to mock the new service imports.

---
https://jules.google.com/session/14443203201187849818