### PR TITLE
feat: add URL scheme validation to prompt renderer

### DIFF
--- a/src/tests/utils/validation.test.js
+++ b/src/tests/utils/validation.test.js
@@ -1,7 +1,41 @@
 import { describe, it, expect } from 'vitest';
-import { validateOwner, validateRepo, validateBranch } from '../../utils/validation.js';
+import { validateOwner, validateRepo, validateBranch, isUrlSafe } from '../../utils/validation.js';
 
 describe('validation.js', () => {
+  describe('isUrlSafe', () => {
+    it('should allow https URLs', () => {
+      expect(isUrlSafe('https://google.com')).toBe(true);
+      expect(isUrlSafe('https://example.com/path?query=1')).toBe(true);
+    });
+
+    it('should allow http URLs for trusted domains', () => {
+      expect(isUrlSafe('http://localhost:3000')).toBe(true);
+      expect(isUrlSafe('http://127.0.0.1:8080')).toBe(true);
+    });
+
+    it('should block http URLs for untrusted domains', () => {
+      expect(isUrlSafe('http://example.com')).toBe(false);
+      expect(isUrlSafe('http://google.com')).toBe(false);
+      expect(isUrlSafe('http://192.168.1.1')).toBe(false);
+    });
+
+    it('should block unsafe schemes', () => {
+      expect(isUrlSafe('javascript:alert(1)')).toBe(false);
+      expect(isUrlSafe('data:text/plain;base64,SGVsbG8=')).toBe(false);
+      expect(isUrlSafe('file:///etc/passwd')).toBe(false);
+      expect(isUrlSafe('content://com.android.providers.media.documents')).toBe(false);
+      expect(isUrlSafe('ftp://example.com')).toBe(false);
+      expect(isUrlSafe('mailto:user@example.com')).toBe(false);
+    });
+
+    it('should handle invalid URLs', () => {
+      expect(isUrlSafe('not-a-url')).toBe(false);
+      expect(isUrlSafe(null)).toBe(false);
+      expect(isUrlSafe(undefined)).toBe(false);
+      expect(isUrlSafe(123)).toBe(false);
+    });
+  });
+
   describe('validateOwner', () => {
     it('should validate correct owner', () => {
       expect(validateOwner('promptroot')).toBe(true);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,6 +6,8 @@ export const OWNER = "promptroot";
 export const REPO = "promptroot";
 export const BRANCH = "main";
 
+export const TRUSTED_DOMAINS = ["localhost", "127.0.0.1"];
+
 // GitHub API
 export const GIST_POINTER_REGEX = /^https:\/\/gist\.githubusercontent\.com\/\S+\/raw\/\S+$/i;
 export const GIST_URL_REGEX = /^https:\/\/gist\.github\.com\/[\w-]+\/[a-f0-9]+\/?(?:#file-[\w.-]+)?(?:\?file=[\w.-]+)?$/i;

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,4 +1,32 @@
+import { TRUSTED_DOMAINS } from './constants.js';
+
 // ===== Validation Functions =====
+
+// URL Scheme Validation
+export function isUrlSafe(url) {
+  if (!url || typeof url !== 'string') return false;
+
+  try {
+    const parsedUrl = new URL(url);
+    const protocol = parsedUrl.protocol.toLowerCase();
+
+    // Allow https everywhere
+    if (protocol === 'https:') {
+      return true;
+    }
+
+    // Allow http only for trusted domains
+    if (protocol === 'http:') {
+      return TRUSTED_DOMAINS.includes(parsedUrl.hostname);
+    }
+
+    // Block everything else (javascript:, data:, file:, content:, etc.)
+    return false;
+  } catch (e) {
+    // Invalid URL format
+    return false;
+  }
+}
 
 // GitHub Owner (Username/Organization) Validation
 export function validateOwner(owner) {


### PR DESCRIPTION
- Added `TRUSTED_DOMAINS` constant in `src/utils/constants.js`.
- Implemented `isUrlSafe` utility in `src/utils/validation.js` to allow `https` and trusted `http` domains, blocking others.
- Added unit tests for `isUrlSafe` in `src/tests/utils/validation.test.js`.
- Integrated validation into `src/modules/prompt-renderer.js` by adding a delegated click listener to intercept unsafe links.
- Updated `DOMPurify` configuration to allow schemes like `file` and `content` to be rendered so they can be intercepted and blocked with a toast notification.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/d2288172-edb1-44d3-b719-dd6382f712c8" />

---
https://jules.google.com/session/714261071990721222