### PR TITLE
Restrict data URI schemes to safe image types

### DIFF
--- a/src/modules/prompt-renderer.js
+++ b/src/modules/prompt-renderer.js
@@ -13,7 +13,7 @@ import { COPEN_OPTIONS, COPEN_STORAGE_KEY, COPEN_DEFAULT_LABEL, COPEN_DEFAULT_IC
 
 let domPurifyHooksInitialized = false;
 
-function sanitizeHtml(html) {
+export function sanitizeHtml(html) {
   if (typeof window.DOMPurify === 'undefined') {
     console.error('DOMPurify not loaded - stripping all HTML tags as safety fallback');
     const div = document.createElement('div');
@@ -49,7 +49,8 @@ function sanitizeHtml(html) {
       'href', 'title', 'alt', 'src', 'class', 'id', 'target', 'rel',
       'colspan', 'rowspan', 'align'
     ],
-    ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|data):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+    // Only allow data:image/ URIs to prevent XSS via data:text/html or other executable types
+    ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp):|data:image\/|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
     ADD_ATTR: ['target'],
     FORBID_TAGS: ['script', 'style', 'iframe', 'object', 'embed', 'base', 'link', 'meta'],
     FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur']

--- a/src/tests/data-uri-security.test.js
+++ b/src/tests/data-uri-security.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { sanitizeHtml } from '../modules/prompt-renderer.js';
+
+describe('Data URI Security', () => {
+  let capturedConfig = null;
+
+  beforeAll(() => {
+    // Mock DOMPurify
+    global.window = global.window || {};
+    global.window.DOMPurify = {
+      sanitize: vi.fn((html, config) => {
+        capturedConfig = config;
+        return html; // Return html as is, we only care about config
+      }),
+      addHook: vi.fn()
+    };
+  });
+
+  afterEach(() => {
+    capturedConfig = null;
+    vi.clearAllMocks();
+  });
+
+  it('should configure ALLOWED_URI_REGEXP to allow safe image data URIs', () => {
+    sanitizeHtml('<p>test</p>');
+
+    expect(capturedConfig).toBeDefined();
+    const regex = capturedConfig.ALLOWED_URI_REGEXP;
+    expect(regex).toBeDefined();
+
+    // Safe images
+    expect(regex.test('data:image/png;base64,abc')).toBe(true);
+    expect(regex.test('data:image/jpeg;base64,abc')).toBe(true);
+    expect(regex.test('data:image/gif;base64,abc')).toBe(true);
+    expect(regex.test('data:image/svg+xml;base64,abc')).toBe(true);
+    expect(regex.test('data:image/webp;base64,abc')).toBe(true);
+  });
+
+  it('should configure ALLOWED_URI_REGEXP to block malicious data URIs', () => {
+    sanitizeHtml('<p>test</p>');
+    const regex = capturedConfig.ALLOWED_URI_REGEXP;
+
+    // Malicious types
+    expect(regex.test('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(regex.test('data:text/javascript,alert(1)')).toBe(false);
+    expect(regex.test('data:application/javascript,alert(1)')).toBe(false);
+
+    // Malformed/Tricky cases
+    expect(regex.test('data:text/html;base64,abc')).toBe(false);
+    // "data:" alone should fail the check for "image/"
+    expect(regex.test('data:')).toBe(false);
+
+    // Regex is `data:image\/` so it expects the slash
+    expect(regex.test('data:image')).toBe(false);
+    expect(regex.test('data:image/')).toBe(true);
+  });
+
+  it('should allow standard schemes', () => {
+    sanitizeHtml('<p>test</p>');
+    const regex = capturedConfig.ALLOWED_URI_REGEXP;
+
+    expect(regex.test('https://example.com')).toBe(true);
+    expect(regex.test('http://example.com')).toBe(true);
+    expect(regex.test('mailto:user@example.com')).toBe(true);
+    expect(regex.test('tel:+1234567890')).toBe(true);
+  });
+
+  it('should block javascript scheme', () => {
+    sanitizeHtml('<p>test</p>');
+    const regex = capturedConfig.ALLOWED_URI_REGEXP;
+
+    expect(regex.test('javascript:alert(1)')).toBe(false);
+    expect(regex.test('vbscript:alert(1)')).toBe(false);
+  });
+});


### PR DESCRIPTION
- Modified `src/modules/prompt-renderer.js` to restrict `ALLOWED_URI_REGEXP` to only allow `data:image/*` URIs.
- Explicitly blocked `data:text/html` and other executable MIME types.
- Exported `sanitizeHtml` for testing purposes.
- Added `src/tests/data-uri-security.test.js` to verify the security fix.

---
https://jules.google.com/session/1800836682166301940