### PR TITLE
feat: add validation and rate limiting to Jules API key input

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -382,3 +382,13 @@ export const CACHE_POLICIES = {
     strategy: CACHE_STRATEGIES.CACHE_FIRST
   }
 };
+
+/**
+ * Jules API key validation configuration
+ */
+export const JULES_API_KEY_CONFIG = {
+  MIN_LENGTH: 20,
+  MAX_LENGTH: 512,
+  PATTERN: /^[A-Za-z0-9_\-]+$/,
+  RATE_LIMIT_MS: 5000
+};


### PR DESCRIPTION
Added validation and rate limiting to the Jules API key input in the modal.
- Defined `JULES_API_KEY_CONFIG` in `src/utils/constants.js` with length and pattern constraints.
- Updated `src/modules/jules-modal.js` to validate the key and enforce a 5-second rate limit.
- Updated `src/tests/modules/jules-modal.test.js` to test the new validation and rate limiting logic, refactoring the test to support module state resetting.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/196269f3-e10f-4dc3-ae86-e66a4b13d9c3" />

---
https://jules.google.com/session/6713563228871028992
