### PR TITLE
feat: add safe fallback for marked.js load failures

### DIFF
--- a/src/tests/modules/prompt-renderer.test.js
+++ b/src/tests/modules/prompt-renderer.test.js
@@ -392,14 +392,37 @@ describe('prompt-renderer', () => {
       });
     });
 
-    it('should handle markdown parsing errors', async () => {
+    it('should handle markdown parsing errors with fallback', async () => {
       const { loadMarked } = await import('../../utils/lazy-loaders.js');
+      const { showToast } = await import('../../modules/toast.js');
+
       loadMarked.mockReset();
       loadMarked.mockRejectedValue(new Error('Markdown parsing failed'));
 
       const mockFile = { path: 'test.md', name: 'test.md', slug: 'test', type: 'file' };
       
-      await expect(selectFile(mockFile, true, 'owner', 'repo', 'main')).rejects.toThrow('Markdown parsing failed');
+      // Should not throw, but handle error gracefully
+      await selectFile(mockFile, true, 'owner', 'repo', 'main');
+
+      expect(showToast).toHaveBeenCalledWith('Markdown rendering unavailable', 'error');
+
+      // contentEl is mocked, verify interactions
+      // We can't easily check internal state of the specific contentEl instance since getElementById returns a new copy/reference from the mock factory or same object?
+      // In the beforeEach: global.document.getElementById.mockImplementation ... returns { ...mockElement, id }
+      // So it returns a new object with spread properties.
+      // But the methods like appendChild are shared from the closure `mockElement`?
+      // No, `mockElement` is defined inside `beforeEach`.
+      // Wait, `const mockElement = { ... }` is inside `beforeEach`.
+      // `global.document.getElementById` uses that `mockElement`.
+      // If I want to spy on the specific element returned for 'content', I should rely on the fact that `initPromptRenderer` was called and stored the reference.
+      // But `selectFile` uses the stored `contentEl`.
+
+      // Let's rely on checking if console.error was called (though mocking it might be needed to avoid noise)
+      // And showToast is mocked.
+
+      // We can also verify that we attempted to append children to contentEl
+      // But since we can't easily access the exact mock instance used inside prompt-renderer without exporting it,
+      // we can verify the side effects like showToast.
     });
 
     it('should handle DOM manipulation errors gracefully', () => {


### PR DESCRIPTION
- Wrap marked.js loading and parsing in try-catch block in prompt-renderer.js
- Implement fallback UI with warning banner and raw text display
- Ensure raw text is rendered safely using textContent
- Update unit tests to verify fallback behavior
- Verified via Playwright by simulating network failure

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/7ea8af59-e957-4367-9f05-4c1d304d5c1a" />

---
https://jules.google.com/session/13737593753276479768