### PR TITLE
Add SRI to DOMPurify and lazy-loaded libraries

### DIFF
--- a/pages/jules/jules.html
+++ b/pages/jules/jules.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" />
   <link rel="stylesheet" href="../../src/styles.css" />
   <script src="../../src/font-init.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js" integrity="sha384-cwS6YdhLI7XS60eoDiC+egV0qHp8zI+Cms46R0nbn8JrmoAzV9uFL60etMZhAnSu" crossorigin="anonymous"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>

--- a/pages/queue/queue.html
+++ b/pages/queue/queue.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" />
   <link rel="stylesheet" href="../../src/styles.css" />
   <script src="../../src/font-init.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js" integrity="sha384-cwS6YdhLI7XS60eoDiC+egV0qHp8zI+Cms46R0nbn8JrmoAzV9uFL60etMZhAnSu" crossorigin="anonymous"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js"></script>

--- a/src/tests/utils/lazy-loaders.test.js
+++ b/src/tests/utils/lazy-loaders.test.js
@@ -55,7 +55,9 @@ describe('lazy-loaders', () => {
       const result = await loadPromise;
       
       expect(document.createElement).toHaveBeenCalledWith('script');
-      expect(capturedScript.src).toBe('https://cdn.jsdelivr.net/npm/marked/marked.min.js');
+      expect(capturedScript.src).toBe('https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js');
+      expect(capturedScript.integrity).toBe('sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+');
+      expect(capturedScript.crossOrigin).toBe('anonymous');
       expect(document.head.appendChild).toHaveBeenCalled();
       expect(result).toBe(markedMock);
     });
@@ -173,7 +175,9 @@ describe('lazy-loaders', () => {
       const result = await loadPromise;
       
       expect(document.createElement).toHaveBeenCalledWith('script');
-      expect(capturedScript.src).toBe('https://cdn.jsdelivr.net/npm/fuse.js/dist/fuse.min.js');
+      expect(capturedScript.src).toBe('https://cdn.jsdelivr.net/npm/fuse.js@7.1.0/dist/fuse.min.js');
+      expect(capturedScript.integrity).toBe('sha384-P/y/5cwqUn6MDvJ9lCHJSaAi2EoH3JSeEdyaORsQMPgbpvA+NvvUqik7XH2YGBjb');
+      expect(capturedScript.crossOrigin).toBe('anonymous');
       expect(document.head.appendChild).toHaveBeenCalled();
       expect(result).toBe(fuseMock);
     });

--- a/src/utils/lazy-loaders.js
+++ b/src/utils/lazy-loaders.js
@@ -19,7 +19,9 @@ export async function loadMarked() {
   
   const promise = new Promise((resolve, reject) => {
     const script = document.createElement('script');
-    script.src = 'https://cdn.jsdelivr.net/npm/marked/marked.min.js';
+    script.src = 'https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js';
+    script.integrity = 'sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+';
+    script.crossOrigin = 'anonymous';
     script.onload = () => {
       loadedLibraries.set('marked', true);
       loadingPromises.delete('marked');
@@ -51,7 +53,9 @@ export async function loadFuse() {
   
   const promise = new Promise((resolve, reject) => {
     const script = document.createElement('script');
-    script.src = 'https://cdn.jsdelivr.net/npm/fuse.js/dist/fuse.min.js';
+    script.src = 'https://cdn.jsdelivr.net/npm/fuse.js@7.1.0/dist/fuse.min.js';
+    script.integrity = 'sha384-P/y/5cwqUn6MDvJ9lCHJSaAi2EoH3JSeEdyaORsQMPgbpvA+NvvUqik7XH2YGBjb';
+    script.crossOrigin = 'anonymous';
     script.onload = () => {
       loadedLibraries.set('fuse', true);
       loadingPromises.delete('fuse');


### PR DESCRIPTION
Pinned versions and added SRI hashes for DOMPurify, Marked.js, and Fuse.js. Updated lazy-loaders.js to include integrity and crossorigin attributes. Updated tests to verify integrity attributes.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/37ada863-f0dc-4a09-925f-a5c5960ab575" />

---
https://jules.google.com/session/576096560355008787