### PR TITLE
Strengthen URL parameter validation in hash routing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,7 @@
 // ===== Main App Initialization =====
 
 import { OWNER, REPO, BRANCH, STORAGE_KEYS } from './utils/constants.js';
-import { parseParams, getHashParam } from './utils/url-params.js';
+import { parseParams } from './utils/url-params.js';
 import statusBar from './modules/status-bar.js';
 import { initPromptList, loadList, loadExpandedState, renderList, setSelectFileCallback, setRepoContext } from './modules/prompt-list.js';
 import { initPromptRenderer, selectBySlug, selectFile, setHandleTryInJulesCallback } from './modules/prompt-renderer.js';
@@ -64,7 +64,7 @@ async function loadPrompts() {
   const cacheKey = STORAGE_KEYS.promptsCache(currentOwner, currentRepo, currentBranch);
   const files = await loadList(currentOwner, currentRepo, currentBranch, cacheKey);
 
-  const hashSlug = getHashParam('p');
+  const { p: hashSlug } = parseParams();
   if (hashSlug) {
     await selectBySlug(hashSlug, files, currentOwner, currentRepo, currentBranch);
   } else {
@@ -97,7 +97,7 @@ function setupEventListeners() {
         await loadBranches();
       } else {
         // Just switching prompt
-        const hashSlug = getHashParam('p');
+        const hashSlug = p.p;
         if (hashSlug) {
           const { getFiles } = await import('./modules/prompt-list.js');
           await selectBySlug(hashSlug, getFiles(), currentOwner, currentRepo, currentBranch);

--- a/src/tests/utils/url-params.test.js
+++ b/src/tests/utils/url-params.test.js
@@ -110,6 +110,18 @@ describe('url-params', () => {
       consoleWarnSpy.mockRestore();
     });
 
+    it('should validate p parameter and reject invalid paths', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      window.location.search = '?p=../secret';
+
+      const params = parseParams();
+
+      expect(params.p).toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalled();
+
+      consoleWarnSpy.mockRestore();
+    });
+
     it('should accept non-validated parameters without validation', () => {
       window.location.search = '?custom=value&another=param&owner=test';
       

--- a/src/tests/utils/validation.test.js
+++ b/src/tests/utils/validation.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateOwner, validateRepo, validateBranch } from '../../utils/validation.js';
+import { validateOwner, validateRepo, validateBranch, validatePath } from '../../utils/validation.js';
 
 describe('validation.js', () => {
   describe('validateOwner', () => {
@@ -39,6 +39,9 @@ describe('validation.js', () => {
       it('should validate correct branch', () => {
           expect(validateBranch('main')).toBe(true);
           expect(validateBranch('feature/branch')).toBe(true);
+          expect(validateBranch('my-branch')).toBe(true);
+          expect(validateBranch('my_branch')).toBe(true);
+          expect(validateBranch('v1.0')).toBe(true);
       });
 
       it('should invalidate incorrect branch', () => {
@@ -48,6 +51,37 @@ describe('validation.js', () => {
           expect(validateBranch('dot..dot')).toBe(false);
           expect(validateBranch('@{')).toBe(false);
           expect(validateBranch('back\\slash')).toBe(false);
+          expect(validateBranch('special$char')).toBe(false);
+          expect(validateBranch('space ')).toBe(false);
+      });
+  });
+
+  describe('validatePath', () => {
+      it('should validate correct path', () => {
+          expect(validatePath('readme.md')).toBe(true);
+          expect(validatePath('src/utils/validation.js')).toBe(true);
+          expect(validatePath('images/logo.png')).toBe(true);
+      });
+
+      it('should invalidate path traversal', () => {
+          expect(validatePath('../secret.txt')).toBe(false);
+          expect(validatePath('folder/../file')).toBe(false);
+          expect(validatePath('..')).toBe(false);
+      });
+
+      it('should invalidate absolute paths', () => {
+          expect(validatePath('/etc/passwd')).toBe(false);
+          expect(validatePath('/usr/bin')).toBe(false);
+      });
+
+      it('should invalidate empty path', () => {
+          expect(validatePath('')).toBe(false);
+      });
+
+      it('should invalidate non-string', () => {
+          expect(validatePath(null)).toBe(false);
+          expect(validatePath(undefined)).toBe(false);
+          expect(validatePath(123)).toBe(false);
       });
   });
 });

--- a/src/utils/url-params.js
+++ b/src/utils/url-params.js
@@ -1,5 +1,5 @@
 // ===== URL Parameter Parsing =====
-import { validateOwner, validateRepo, validateBranch } from './validation.js';
+import { validateOwner, validateRepo, validateBranch, validatePath } from './validation.js';
 
 export function parseParams() {
   const out = {};
@@ -13,7 +13,8 @@ export function parseParams() {
   const validationMap = {
     owner: validateOwner,
     repo: validateRepo,
-    branch: validateBranch
+    branch: validateBranch,
+    p: validatePath
   };
 
   for (const src of sources) {

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -27,14 +27,19 @@ export function validateBranch(branch) {
   if (typeof branch !== 'string' || branch.length < 1 || branch.length > 250) {
     return false;
   }
-  // Cannot start or end with '/', no '..' or '@{'
+
+  // Allowlist: alphanumeric, hyphen, underscore, forward slash, period
+  const validBranchRegex = /^[a-zA-Z0-9_\/.-]+$/;
+  if (!validBranchRegex.test(branch)) {
+    return false;
+  }
+
+  // Additional checks for structural validity
   const invalidPatterns = [
     /^\//,    // Starts with '/'
     /\/$/,    // Ends with '/'
-    /\/\//,  // Contains '//'
+    /\/\//,   // Contains '//'
     /\.\./,   // Contains '..'
-    /@\{/,   // Contains '@{'
-    /\\/,     // Contains '\'
   ];
 
   for (const pattern of invalidPatterns) {
@@ -43,10 +48,22 @@ export function validateBranch(branch) {
     }
   }
 
-  // Control characters and some special characters are not allowed
-  // eslint-disable-next-line no-control-regex
-  const controlCharsRegex = /[\u0000-\u001f\u007f~^:?*\[\]]/;
-  if (controlCharsRegex.test(branch)) {
+  return true;
+}
+
+// Path Validation
+export function validatePath(path) {
+  if (typeof path !== 'string' || path.length < 1) {
+    return false;
+  }
+
+  // Reject path traversal
+  if (path.includes('..')) {
+    return false;
+  }
+
+  // Reject absolute paths
+  if (path.startsWith('/')) {
     return false;
   }
 


### PR DESCRIPTION
- Implement `validatePath` in `src/utils/validation.js` to reject path traversal (`..`) and absolute paths (`/`).
- Update `validateBranch` to enforce strict allowlist (alphanumeric, `_`, `-`, `/`, `.`) and reject `..`.
- Update `parseParams` in `src/utils/url-params.js` to use `validatePath` for parameter `p`.
- Update `src/app.js` to use `parseParams().p` ensuring validation is applied.
- Remove unused `getHashParam` from `src/app.js`.
- Add tests for new validation logic.

---
https://jules.google.com/session/16750006058332705999