### PR TITLE
Add SRI for DOMPurify and lazy-loaded libraries

### DIFF
--- a/pages/jules/jules.html
+++ b/pages/jules/jules.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" />
   <link rel="stylesheet" href="../../src/styles.css" />
   <script src="../../src/font-init.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js" integrity="sha384-cwS6YdhLI7XS60eoDiC+egV0qHp8zI+Cms46R0nbn8JrmoAzV9uFL60etMZhAnSu" crossorigin="anonymous"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-app-compat.js" integrity="sha384-BkEIW/B4JV9w6pRfBRgZtAcYDk5goH1nUI49rLo8s5PSHgTfgxWBczRVJx+fv5kP" crossorigin="anonymous"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js" integrity="sha384-96KlrabK9X4T/tq4duY+/4JE60jZAiSs4QVJFwmY30ETT24x2+89B7qmq7O4IETX" crossorigin="anonymous"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js" integrity="sha384-LF74FIj8PQKxRVken52qSHntBSVEC6b05H04maSVJibifVGmWz9Ajc23WjrRVSCX" crossorigin="anonymous"></script>

--- a/pages/queue/queue.html
+++ b/pages/queue/queue.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" />
   <link rel="stylesheet" href="../../src/styles.css" />
   <script src="../../src/font-init.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js" integrity="sha384-cwS6YdhLI7XS60eoDiC+egV0qHp8zI+Cms46R0nbn8JrmoAzV9uFL60etMZhAnSu" crossorigin="anonymous"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-app-compat.js" integrity="sha384-BkEIW/B4JV9w6pRfBRgZtAcYDk5goH1nUI49rLo8s5PSHgTfgxWBczRVJx+fv5kP" crossorigin="anonymous"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-auth-compat.js" integrity="sha384-96KlrabK9X4T/tq4duY+/4JE60jZAiSs4QVJFwmY30ETT24x2+89B7qmq7O4IETX" crossorigin="anonymous"></script>
   <script src="https://www.gstatic.com/firebasejs/10.7.0/firebase-firestore-compat.js" integrity="sha384-LF74FIj8PQKxRVken52qSHntBSVEC6b05H04maSVJibifVGmWz9Ajc23WjrRVSCX" crossorigin="anonymous"></script>

--- a/src/unit-tests/utils/lazy-loaders.test.js
+++ b/src/unit-tests/utils/lazy-loaders.test.js
@@ -55,7 +55,9 @@ describe('lazy-loaders', () => {
       const result = await loadPromise;
       
       expect(document.createElement).toHaveBeenCalledWith('script');
-      expect(capturedScript.src).toBe('https://cdn.jsdelivr.net/npm/marked/marked.min.js');
+      expect(capturedScript.src).toBe('https://cdn.jsdelivr.net/npm/marked@17.0.1/marked.min.js');
+      expect(capturedScript.integrity).toBe('sha384-tkjnnf9Tzhv5ZFrDroGvUExw9C3EVFo0RFRkzKR8ZX4b5Psoec4yb1PlD8Jh4j4H');
+      expect(capturedScript.crossOrigin).toBe('anonymous');
       expect(document.head.appendChild).toHaveBeenCalled();
       expect(result).toBe(markedMock);
     });
@@ -173,7 +175,9 @@ describe('lazy-loaders', () => {
       const result = await loadPromise;
       
       expect(document.createElement).toHaveBeenCalledWith('script');
-      expect(capturedScript.src).toBe('https://cdn.jsdelivr.net/npm/fuse.js/dist/fuse.min.js');
+      expect(capturedScript.src).toBe('https://cdn.jsdelivr.net/npm/fuse.js@7.1.0/dist/fuse.min.js');
+      expect(capturedScript.integrity).toBe('sha384-P/y/5cwqUn6MDvJ9lCHJSaAi2EoH3JSeEdyaORsQMPgbpvA+NvvUqik7XH2YGBjb');
+      expect(capturedScript.crossOrigin).toBe('anonymous');
       expect(document.head.appendChild).toHaveBeenCalled();
       expect(result).toBe(fuseMock);
     });

--- a/src/utils/lazy-loaders.js
+++ b/src/utils/lazy-loaders.js
@@ -19,7 +19,9 @@ export async function loadMarked() {
   
   const promise = new Promise((resolve, reject) => {
     const script = document.createElement('script');
-    script.src = 'https://cdn.jsdelivr.net/npm/marked/marked.min.js';
+    script.src = 'https://cdn.jsdelivr.net/npm/marked@17.0.1/marked.min.js';
+    script.integrity = 'sha384-tkjnnf9Tzhv5ZFrDroGvUExw9C3EVFo0RFRkzKR8ZX4b5Psoec4yb1PlD8Jh4j4H';
+    script.crossOrigin = 'anonymous';
     script.onload = () => {
       loadedLibraries.set('marked', true);
       loadingPromises.delete('marked');
@@ -51,7 +53,9 @@ export async function loadFuse() {
   
   const promise = new Promise((resolve, reject) => {
     const script = document.createElement('script');
-    script.src = 'https://cdn.jsdelivr.net/npm/fuse.js/dist/fuse.min.js';
+    script.src = 'https://cdn.jsdelivr.net/npm/fuse.js@7.1.0/dist/fuse.min.js';
+    script.integrity = 'sha384-P/y/5cwqUn6MDvJ9lCHJSaAi2EoH3JSeEdyaORsQMPgbpvA+NvvUqik7XH2YGBjb';
+    script.crossOrigin = 'anonymous';
     script.onload = () => {
       loadedLibraries.set('fuse', true);
       loadingPromises.delete('fuse');


### PR DESCRIPTION
### Motivation
- Improve supply-chain security by adding Subresource Integrity (SRI) and `crossorigin` attributes to third-party scripts loaded from CDNs.

### Description
- Add `integrity` and `crossorigin="anonymous"` to the DOMPurify script tag in `pages/jules/jules.html` and `pages/queue/queue.html`.
- Pin `marked` and `fuse.js` to specific CDN versions and add `integrity` and `crossOrigin` attributes in `src/utils/lazy-loaders.js` (update `loadMarked()` and `loadFuse()` to set `script.src`, `script.integrity`, and `script.crossOrigin`).
- Update unit tests in `src/unit-tests/utils/lazy-loaders.test.js` to expect the new pinned CDN URLs and the `integrity`/`crossOrigin` properties on created script elements.

### Testing
- Computed SRI hashes for `marked@17.0.1` and `fuse.js@7.1.0` using `curl` + `openssl` and applied the resulting `sha384` values to the loader and test assertions, which completed successfully.
- Updated unit tests to assert the new attributes but did not run the full test suite (`vitest`) in this change; no automated test failures reported because tests were not executed.
- Verified file changes and committed them (`git`), and confirmed the modified files are: `pages/jules/jules.html`, `pages/queue/queue.html`, `src/utils/lazy-loaders.js`, and `src/unit-tests/utils/lazy-loaders.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba4e562a8832b8e03b26d03c79d17)