### PR TITLE
Add user-scoped session cache keys and per-user cache clearing

### DIFF
--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -1,7 +1,7 @@
 // ===== Firebase Authentication Module =====
 
 import { showToast } from './toast.js';
-import { setCache, getCache } from '../utils/session-cache.js';
+import { setCache, getCache, clearUserCache } from '../utils/session-cache.js';
 import { getAuth } from './firebase-service.js';
 // Lazy loaded: jules-api.js (for clearJulesKeyCache)
 
@@ -62,6 +62,7 @@ export async function switchGitHubAccount() {
     // Sign out the current user first
     const auth = getAuth();
     if (auth?.currentUser) {
+      clearUserCache(auth.currentUser.uid);
       await signOutUser();
     }
     
@@ -76,6 +77,7 @@ export async function switchGitHubAccount() {
 export async function signOutUser() {
   try {
     const auth = getAuth();
+    clearUserCache(auth?.currentUser?.uid || null);
     if (auth) {
       // Clear Jules API key cache on logout
       if (auth.currentUser) {

--- a/src/modules/branch-selector.js
+++ b/src/modules/branch-selector.js
@@ -307,13 +307,14 @@ export async function loadBranches() {
 
   try {
     // Check cache first
-    const cacheKey = `${currentOwner}/${currentRepo}`;
-    let branches = getCache(CACHE_KEYS.BRANCHES, cacheKey);
+    const cacheScopeKey = `${currentOwner}/${currentRepo}`;
+    const userId = getCurrentUser()?.uid || null;
+    let branches = getCache(CACHE_KEYS.BRANCHES, userId, cacheScopeKey);
     
     if (!branches) {
       // Load from API and cache
       branches = await getBranches(currentOwner, currentRepo);
-      setCache(CACHE_KEYS.BRANCHES, branches, cacheKey);
+      setCache(CACHE_KEYS.BRANCHES, branches, userId, cacheScopeKey);
     }
 
     allBranches = branches;

--- a/src/tests/modules/branch-selector.test.js
+++ b/src/tests/modules/branch-selector.test.js
@@ -524,6 +524,7 @@ describe('branch-selector', () => {
       expect(setCache).toHaveBeenCalledWith(
         CACHE_KEYS.BRANCHES,
         expect.any(Array),
+        null,
         'owner1/repo1'
       );
     });

--- a/src/unit-tests/modules/auth.test.js
+++ b/src/unit-tests/modules/auth.test.js
@@ -16,7 +16,8 @@ vi.mock('../../modules/toast.js', () => ({
 
 vi.mock('../../utils/session-cache.js', () => ({
   setCache: vi.fn(),
-  getCache: vi.fn()
+  getCache: vi.fn(),
+  clearUserCache: vi.fn()
 }));
 
 vi.mock('../../modules/jules-api.js', () => ({

--- a/src/unit-tests/modules/branch-selector.test.js
+++ b/src/unit-tests/modules/branch-selector.test.js
@@ -535,6 +535,7 @@ describe('branch-selector', () => {
       expect(setCache).toHaveBeenCalledWith(
         CACHE_KEYS.BRANCHES,
         expect.any(Array),
+        null,
         'owner1/repo1'
       );
     });

--- a/src/unit-tests/utils/session-cache.test.js
+++ b/src/unit-tests/utils/session-cache.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { setCache, getCache, getCacheState, clearCache, clearAllCache, CACHE_KEYS } from '../../utils/session-cache.js';
+import { setCache, getCache, getCacheState, clearCache, clearAllCache, clearUserCache, CACHE_KEYS } from '../../utils/session-cache.js';
 import { CACHE_STRATEGIES } from '../../utils/constants.js';
 
 describe('session-cache', () => {
@@ -7,6 +7,7 @@ describe('session-cache', () => {
 
   beforeEach(() => {
     sessionStorage.clear();
+    localStorage.removeItem('github_access_token');
     originalDateNow = Date.now;
   });
 
@@ -38,7 +39,7 @@ describe('session-cache', () => {
 
       setCache('test_key', testData);
 
-      const stored = JSON.parse(sessionStorage.getItem('test_key'));
+      const stored = JSON.parse(sessionStorage.getItem('test_key::guest'));
       expect(stored.data).toEqual(testData);
       expect(stored.timestamp).toBe(mockTime);
     });
@@ -48,8 +49,8 @@ describe('session-cache', () => {
       
       setCache('test_key', testData, 'user123');
 
-      expect(sessionStorage.getItem('test_key_user123')).toBeDefined();
-      expect(sessionStorage.getItem('test_key')).toBeNull();
+      expect(sessionStorage.getItem('test_key::uid:user123')).toBeDefined();
+      expect(sessionStorage.getItem('test_key::guest')).toBeNull();
     });
 
     it('should handle complex data structures', () => {
@@ -62,7 +63,7 @@ describe('session-cache', () => {
 
       setCache('complex', complexData);
 
-      const stored = JSON.parse(sessionStorage.getItem('complex'));
+      const stored = JSON.parse(sessionStorage.getItem('complex::guest'));
       expect(stored.data).toEqual(complexData);
     });
 
@@ -85,7 +86,7 @@ describe('session-cache', () => {
       setCache('key', { value: 'old' });
       setCache('key', { value: 'new' });
 
-      const stored = JSON.parse(sessionStorage.getItem('key'));
+      const stored = JSON.parse(sessionStorage.getItem('key::guest'));
       expect(stored.data.value).toBe('new');
     });
   });
@@ -249,13 +250,13 @@ describe('session-cache', () => {
       getCache('expiring_key');
 
       // Should be removed from storage
-      expect(sessionStorage.getItem('expiring_key')).toBeNull();
+      expect(sessionStorage.getItem('expiring_key::guest')).toBeNull();
     });
 
     it('should handle invalid JSON gracefully', () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       
-      sessionStorage.setItem('bad_json', '{invalid json}');
+      sessionStorage.setItem('bad_json::guest', '{invalid json}');
 
       const retrieved = getCache('bad_json');
       
@@ -282,7 +283,7 @@ describe('session-cache', () => {
     });
 
     it('should handle missing timestamp in cached data', () => {
-      sessionStorage.setItem('bad_format', JSON.stringify({ data: 'test' }));
+      sessionStorage.setItem('bad_format::guest', JSON.stringify({ data: 'test' }));
 
       const retrieved = getCache('bad_format');
       
@@ -298,8 +299,8 @@ describe('session-cache', () => {
 
       clearCache('key1');
 
-      expect(sessionStorage.getItem('key1')).toBeNull();
-      expect(sessionStorage.getItem('key2')).not.toBeNull();
+      expect(sessionStorage.getItem('key1::guest')).toBeNull();
+      expect(sessionStorage.getItem('key2::guest')).not.toBeNull();
     });
 
     it('should clear cache with userId suffix', () => {
@@ -307,7 +308,7 @@ describe('session-cache', () => {
 
       clearCache('key', 'user123');
 
-      expect(sessionStorage.getItem('key_user123')).toBeNull();
+      expect(sessionStorage.getItem('key::uid:user123')).toBeNull();
     });
 
     it('should handle clearing non-existent cache', () => {
@@ -352,6 +353,20 @@ describe('session-cache', () => {
       }).not.toThrow();
 
       sessionStorage.clear = originalClear;
+    });
+  });
+
+  describe('clearUserCache', () => {
+    it('should clear cache entries for a specific user identity', () => {
+      setCache('key1', { data: 'test1' }, 'user123');
+      setCache('key2', { data: 'test2' }, 'user123');
+      setCache('key3', { data: 'test3' }, 'user456');
+
+      clearUserCache('user123');
+
+      expect(sessionStorage.getItem('key1::uid:user123')).toBeNull();
+      expect(sessionStorage.getItem('key2::uid:user123')).toBeNull();
+      expect(sessionStorage.getItem('key3::uid:user456')).not.toBeNull();
     });
   });
 

--- a/src/utils/session-cache.js
+++ b/src/utils/session-cache.js
@@ -1,15 +1,59 @@
 // Session storage cache utilities
 import { CACHE_DURATIONS, CACHE_KEYS, CACHE_POLICIES, CACHE_STRATEGIES } from './constants.js';
+import { getAuth } from '../modules/firebase-service.js';
 
 export { CACHE_KEYS };
 
-function getCacheKey(key, userId) {
-  return userId ? `${key}_${userId}` : key;
+function hashToken(token) {
+  let hash = 0;
+  for (let i = 0; i < token.length; i++) {
+    hash = ((hash << 5) - hash) + token.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36);
 }
 
-export function setCache(key, data, userId = null) {
+function getStoredToken() {
   try {
-    const cacheKey = getCacheKey(key, userId);
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem('github_access_token');
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === 'string') return parsed;
+    return parsed?.token || null;
+  } catch (error) {
+    console.warn('Failed to parse stored GitHub token for cache keying:', error);
+    return null;
+  }
+}
+
+function getUserCacheIdentity(userId) {
+  if (userId) {
+    return `uid:${userId}`;
+  }
+
+  const authUserId = getAuth()?.currentUser?.uid;
+  if (authUserId) {
+    return `uid:${authUserId}`;
+  }
+
+  const token = getStoredToken();
+  if (token) {
+    return `token:${hashToken(token)}`;
+  }
+
+  return 'guest';
+}
+
+function getCacheKey(key, userId, scopeKey = null) {
+  const identity = getUserCacheIdentity(userId);
+  const scopeSuffix = scopeKey ? `:${scopeKey}` : '';
+  return `${key}${scopeSuffix}::${identity}`;
+}
+
+export function setCache(key, data, userId = null, scopeKey = null) {
+  try {
+    const cacheKey = getCacheKey(key, userId, scopeKey);
     const cacheData = {
       data,
       timestamp: Date.now()
@@ -26,9 +70,9 @@ export function setCache(key, data, userId = null) {
  * @param {string} [userId] - Optional user ID
  * @returns {object} Cache state metadata
  */
-export function getCacheState(key, userId = null) {
+export function getCacheState(key, userId = null, scopeKey = null) {
   try {
-    const cacheKey = getCacheKey(key, userId);
+    const cacheKey = getCacheKey(key, userId, scopeKey);
     const cached = sessionStorage.getItem(cacheKey);
     const policy = CACHE_POLICIES[key] || CACHE_POLICIES.DEFAULT;
 
@@ -75,9 +119,9 @@ export function getCacheState(key, userId = null) {
   }
 }
 
-export function getCache(key, userId = null) {
+export function getCache(key, userId = null, scopeKey = null) {
   try {
-    const state = getCacheState(key, userId);
+    const state = getCacheState(key, userId, scopeKey);
     
     if (!state.exists) return null;
 
@@ -86,24 +130,24 @@ export function getCache(key, userId = null) {
       switch (state.policy.strategy) {
         case CACHE_STRATEGIES.CACHE_FIRST:
           // Expired cache is invalid - clear and return null
-          clearCache(key, userId);
+          clearCache(key, userId, scopeKey);
           return null;
         
         case CACHE_STRATEGIES.STALE_WHILE_REVALIDATE:
           // SWR would return stale data and trigger background refresh
           // Not implemented yet - treat as CACHE_FIRST for now
-          clearCache(key, userId);
+          clearCache(key, userId, scopeKey);
           return null;
         
         case CACHE_STRATEGIES.NETWORK_ONLY:
           // Network-only doesn't use cache - this shouldn't happen
           // but clear and return null to be safe
-          clearCache(key, userId);
+          clearCache(key, userId, scopeKey);
           return null;
         
         default:
           // Unknown strategy - fail safe by clearing stale cache
-          clearCache(key, userId);
+          clearCache(key, userId, scopeKey);
           return null;
       }
     }
@@ -115,12 +159,27 @@ export function getCache(key, userId = null) {
   }
 }
 
-export function clearCache(key, userId = null) {
+export function clearCache(key, userId = null, scopeKey = null) {
   try {
-    const cacheKey = getCacheKey(key, userId);
+    const cacheKey = getCacheKey(key, userId, scopeKey);
     sessionStorage.removeItem(cacheKey);
   } catch (error) {
     console.error('Error clearing cache:', error);
+  }
+}
+
+export function clearUserCache(userId = null) {
+  try {
+    const identity = getUserCacheIdentity(userId);
+    const identitySuffix = `::${identity}`;
+    for (let i = sessionStorage.length - 1; i >= 0; i--) {
+      const key = sessionStorage.key(i);
+      if (key && key.endsWith(identitySuffix)) {
+        sessionStorage.removeItem(key);
+      }
+    }
+  } catch (error) {
+    console.error('Error clearing user cache:', error);
   }
 }
 


### PR DESCRIPTION
### Motivation

- Prevent cross-user leakage from sessionStorage by namespacing cache entries with a user identity (UID or token hash) and scope where appropriate. 
- Ensure caches are invalidated when the active account changes (sign-out / account switch) so the next user does not see previous user's data. 
- Keep cache behavior backward-compatible and maintain existing cache policies while adding per-user isolation.

### Description

- Implemented user-aware cache keying in `src/utils/session-cache.js` by adding `hashToken`, `getStoredToken`, `getUserCacheIdentity`, updating `getCacheKey` to produce keys like `<key>:<scope>::uid:<uid>` or `token:<hash>` for unauthenticated token-based identity, and extended `setCache`, `getCache`, `getCacheState`, and `clearCache` to accept an optional `scopeKey` parameter. 
- Added `clearUserCache(userId)` in `src/utils/session-cache.js` to remove all sessionStorage entries for a given user identity. 
- Updated callers to pass user identity / scope where applicable: `src/modules/branch-selector.js` now scopes the `BRANCHES` cache by repo (`owner/repo`) and current user, and `src/modules/auth.js` now invokes `clearUserCache` on `signOutUser()` and before switching accounts. 
- Updated unit/integration test files to reflect the new cache key format and API: `src/unit-tests/utils/session-cache.test.js`, `src/unit-tests/modules/branch-selector.test.js`, `src/unit-tests/modules/auth.test.js`, and `src/tests/modules/branch-selector.test.js` were modified to assert the new key names and to add a test for `clearUserCache`.

### Testing

- No automated test suite was executed as part of this change; the patch updates unit tests but does not run them here. 
- Unit tests updated: `src/unit-tests/utils/session-cache.test.js`, `src/unit-tests/modules/branch-selector.test.js`, `src/unit-tests/modules/auth.test.js`, and `src/tests/modules/branch-selector.test.js` to account for the new key format and to add `clearUserCache` coverage. 
- Please run the project test suite (for example `vitest` / `npm test`) to validate behavior and ensure all tests pass after these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba4b60468832b9b3e2bbd8f77aa38)