### PR TITLE
Refactor jules-modal.js strings to constants

### DIFF
--- a/src/modules/jules-modal.js
+++ b/src/modules/jules-modal.js
@@ -7,7 +7,7 @@ import { RepoSelector, BranchSelector } from './repo-branch-selector.js';
 import { addToJulesQueue } from './jules-queue.js';
 import { toggleVisibility } from '../utils/dom-helpers.js';
 import { extractTitleFromPrompt } from '../utils/title.js';
-import { RETRY_CONFIG, TIMEOUTS, JULES_MESSAGES } from '../utils/constants.js';
+import { RETRY_CONFIG, TIMEOUTS, JULES_MESSAGES, JULES_MODAL_TEXT } from '../utils/constants.js';
 import { showToast } from './toast.js';
 
 let lastSelectedSourceId = 'sources/github/promptroot/promptroot';
@@ -44,33 +44,33 @@ export function showJulesKeyModal(onSave) {
   const handleSave = async () => {
     const apiKey = input.value.trim();
     if (!apiKey) {
-      showToast('Please enter your Jules API key.', 'warn');
+      showToast(JULES_MODAL_TEXT.ENTER_API_KEY, 'warn');
       return;
     }
 
     try {
-      saveBtn.textContent = 'Saving...';
+      saveBtn.textContent = JULES_MODAL_TEXT.SAVING;
       saveBtn.disabled = true;
 
       const user = getAuth()?.currentUser || null;
       if (!user) {
-        showToast('Not logged in.', 'error');
-        saveBtn.textContent = 'Save & Continue';
+        showToast(JULES_MODAL_TEXT.NOT_LOGGED_IN, 'error');
+        saveBtn.textContent = JULES_MODAL_TEXT.SAVE_BUTTON;
         saveBtn.disabled = false;
         return;
       }
 
       await encryptAndStoreKey(apiKey, user.uid);
 
-      showToast('Jules API key saved successfully', 'success');
+      showToast(JULES_MODAL_TEXT.KEY_SAVED_SUCCESS, 'success');
       hideJulesKeyModal();
-      saveBtn.textContent = 'Save & Continue';
+      saveBtn.textContent = JULES_MODAL_TEXT.SAVE_BUTTON;
       saveBtn.disabled = false;
 
       if (onSave) onSave();
     } catch (error) {
-      showToast('Failed to save API key: ' + error.message, 'error');
-      saveBtn.textContent = 'Save & Continue';
+      showToast(JULES_MODAL_TEXT.SAVE_KEY_ERROR(error.message), 'error');
+      saveBtn.textContent = JULES_MODAL_TEXT.SAVE_BUTTON;
       saveBtn.disabled = false;
     }
   };
@@ -155,7 +155,7 @@ export async function showJulesEnvModal(promptText) {
         prompt: promptText,
         sourceId: selectedSourceId,
         branch: selectedBranch,
-        note: 'Queued from Try in Jules modal'
+        note: JULES_MODAL_TEXT.NOTE_QUEUED_MODAL
       });
       showToast(JULES_MESSAGES.QUEUED, 'success');
       hideJulesEnvModal();
@@ -216,7 +216,7 @@ async function handleRepoSelect(sourceId, branch, promptText, suppressPopups = f
               prompt: promptText,
               sourceId: sourceId,
               branch: lastSelectedBranch,
-              note: 'Queued from Try in Jules flow (partial retries)'
+              note: JULES_MODAL_TEXT.NOTE_QUEUED_PARTIAL
             });
             showToast(JULES_MESSAGES.QUEUED, 'success');
           } catch (err) {
@@ -249,7 +249,7 @@ async function handleRepoSelect(sourceId, branch, promptText, suppressPopups = f
               prompt: promptText,
               sourceId: sourceId,
               branch: lastSelectedBranch,
-              note: 'Queued from Try in Jules flow (final failure)'
+              note: JULES_MODAL_TEXT.NOTE_QUEUED_FINAL
             });
             showToast(JULES_MESSAGES.QUEUED, 'success');
           } catch (err) {
@@ -314,7 +314,7 @@ export async function showSubtaskErrorModal(subtaskNumber, totalSubtasks, error,
   }
 
   return new Promise((resolve) => {
-    subtaskNumDiv.textContent = `Task ${subtaskNumber} of ${totalSubtasks}`;
+    subtaskNumDiv.textContent = JULES_MODAL_TEXT.SUBTASK_PROGRESS(subtaskNumber, totalSubtasks);
     messageDiv.textContent = error.message || String(error);
     detailsDiv.textContent = error.toString();
 

--- a/src/unit-tests/modules/jules-modal.test.js
+++ b/src/unit-tests/modules/jules-modal.test.js
@@ -51,8 +51,23 @@ vi.mock('../../utils/constants.js', () => ({
     SIGN_IN_REQUIRED: 'Please sign in',
     QUEUED: 'Added to queue',
     QUEUE_FAILED: (msg) => `Failed: ${msg}`
+  },
+  JULES_MODAL_TEXT: {
+    ENTER_API_KEY: 'Please enter your Jules API key.',
+    SAVING: 'Saving...',
+    NOT_LOGGED_IN: 'Not logged in.',
+    SAVE_BUTTON: 'Save & Continue',
+    KEY_SAVED_SUCCESS: 'Jules API key saved successfully',
+    SAVE_KEY_ERROR: (msg) => 'Failed to save API key: ' + msg,
+    NOTE_QUEUED_MODAL: 'Queued from Try in Jules modal',
+    NOTE_QUEUED_PARTIAL: 'Queued from Try in Jules flow (partial retries)',
+    NOTE_QUEUED_FINAL: 'Queued from Try in Jules flow (final failure)',
+    SUBTASK_PROGRESS: (current, total) => `Task ${current} of ${total}`,
+    SUBTASK_ERROR_TITLE: 'Subtask Error'
   }
 }));
+
+import { JULES_MODAL_TEXT } from '../../utils/constants.js';
 
 vi.mock('../../modules/toast.js', () => ({
   showToast: vi.fn()
@@ -249,7 +264,7 @@ describe('jules-modal', () => {
       
       await mockSaveBtn.onclick();
       
-      expect(showToast).toHaveBeenCalledWith('Please enter your Jules API key.', 'warn');
+      expect(showToast).toHaveBeenCalledWith(JULES_MODAL_TEXT.ENTER_API_KEY, 'warn');
     });
 
     it('should show error if user not logged in', async () => {
@@ -274,8 +289,8 @@ describe('jules-modal', () => {
       
       await mockSaveBtn.onclick();
       
-      expect(showToast).toHaveBeenCalledWith('Not logged in.', 'error');
-      expect(mockSaveBtn.textContent).toBe('Save & Continue');
+      expect(showToast).toHaveBeenCalledWith(JULES_MODAL_TEXT.NOT_LOGGED_IN, 'error');
+      expect(mockSaveBtn.textContent).toBe(JULES_MODAL_TEXT.SAVE_BUTTON);
       expect(mockSaveBtn.disabled).toBe(false);
     });
 
@@ -288,7 +303,7 @@ describe('jules-modal', () => {
       
       const mockModal = createMockElement('julesKeyModal');
       const mockInput = createMockElement('julesKeyInput');
-      const mockSaveBtn = createMockElement('julesSaveBtn', { textContent: 'Save & Continue' });
+      const mockSaveBtn = createMockElement('julesSaveBtn', { textContent: JULES_MODAL_TEXT.SAVE_BUTTON });
       const mockCancelBtn = createMockElement('julesCancelBtn');
       
       global.document.getElementById.mockImplementation((id) => {
@@ -305,9 +320,9 @@ describe('jules-modal', () => {
       await mockSaveBtn.onclick();
       
       expect(encryptAndStoreKey).toHaveBeenCalledWith('my-api-key', 'user123');
-      expect(showToast).toHaveBeenCalledWith('Jules API key saved successfully', 'success');
+      expect(showToast).toHaveBeenCalledWith(JULES_MODAL_TEXT.KEY_SAVED_SUCCESS, 'success');
       expect(mockModal.classList.remove).toHaveBeenCalledWith('show');
-      expect(mockSaveBtn.textContent).toBe('Save & Continue');
+      expect(mockSaveBtn.textContent).toBe(JULES_MODAL_TEXT.SAVE_BUTTON);
       expect(mockSaveBtn.disabled).toBe(false);
     });
 
@@ -319,7 +334,7 @@ describe('jules-modal', () => {
       
       const mockModal = createMockElement('julesKeyModal');
       const mockInput = createMockElement('julesKeyInput');
-      const mockSaveBtn = createMockElement('julesSaveBtn', { textContent: 'Save & Continue' });
+      const mockSaveBtn = createMockElement('julesSaveBtn', { textContent: JULES_MODAL_TEXT.SAVE_BUTTON });
       const mockCancelBtn = createMockElement('julesCancelBtn');
       
       global.document.getElementById.mockImplementation((id) => {
@@ -337,7 +352,7 @@ describe('jules-modal', () => {
       await mockSaveBtn.onclick();
       
       expect(onSaveCallback).toHaveBeenCalled();
-      expect(mockSaveBtn.textContent).toBe('Save & Continue');
+      expect(mockSaveBtn.textContent).toBe(JULES_MODAL_TEXT.SAVE_BUTTON);
       expect(mockSaveBtn.disabled).toBe(false);
     });
 
@@ -350,7 +365,7 @@ describe('jules-modal', () => {
       
       const mockModal = createMockElement('julesKeyModal');
       const mockInput = createMockElement('julesKeyInput');
-      const mockSaveBtn = createMockElement('julesSaveBtn', { textContent: 'Save & Continue' });
+      const mockSaveBtn = createMockElement('julesSaveBtn', { textContent: JULES_MODAL_TEXT.SAVE_BUTTON });
       const mockCancelBtn = createMockElement('julesCancelBtn');
       
       global.document.getElementById.mockImplementation((id) => {
@@ -366,8 +381,8 @@ describe('jules-modal', () => {
       
       await mockSaveBtn.onclick();
       
-      expect(showToast).toHaveBeenCalledWith('Failed to save API key: Storage failed', 'error');
-      expect(mockSaveBtn.textContent).toBe('Save & Continue');
+      expect(showToast).toHaveBeenCalledWith(JULES_MODAL_TEXT.SAVE_KEY_ERROR('Storage failed'), 'error');
+      expect(mockSaveBtn.textContent).toBe(JULES_MODAL_TEXT.SAVE_BUTTON);
       expect(mockSaveBtn.disabled).toBe(false);
     });
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -199,6 +199,21 @@ export const JULES_MESSAGES = {
   FINAL_RETRY_FAILED: "Failed to submit task after multiple retries. Please try again later."
 };
 
+// Jules Modal UI text
+export const JULES_MODAL_TEXT = {
+  ENTER_API_KEY: 'Please enter your Jules API key.',
+  SAVING: 'Saving...',
+  NOT_LOGGED_IN: 'Not logged in.',
+  SAVE_BUTTON: 'Save & Continue',
+  KEY_SAVED_SUCCESS: 'Jules API key saved successfully',
+  SAVE_KEY_ERROR: (msg) => 'Failed to save API key: ' + msg,
+  NOTE_QUEUED_MODAL: 'Queued from Try in Jules modal',
+  NOTE_QUEUED_PARTIAL: 'Queued from Try in Jules flow (partial retries)',
+  NOTE_QUEUED_FINAL: 'Queued from Try in Jules flow (final failure)',
+  SUBTASK_PROGRESS: (current, total) => `Task ${current} of ${total}`,
+  SUBTASK_ERROR_TITLE: 'Subtask Error'
+};
+
 // UI text
 export const UI_TEXT = {
   LOADING: "Loading...",


### PR DESCRIPTION
Extracted hardcoded UI strings from `src/modules/jules-modal.js` into a new `JULES_MODAL_TEXT` object in `src/utils/constants.js`. Updated `src/modules/jules-modal.js` to import and use these constants. Updated unit tests in `src/unit-tests/modules/jules-modal.test.js` to mock and assert against the new constants. Verified with unit tests and a Playwright script.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/ddd3708d-601b-42ef-a40a-5623eb033422" />

---
*PR created automatically by Jules for task [5422654683906310049](https://jules.google.com/task/5422654683906310049) started by @dogi*