### PR TITLE
Refactor markdown fallback to use CSS classes

### DIFF
--- a/src/modules/prompt-renderer.js
+++ b/src/modules/prompt-renderer.js
@@ -497,19 +497,13 @@ export async function selectFile(f, pushHash, owner, repo, branch) {
 
     // Warning banner
     const warningDiv = document.createElement('div');
-    warningDiv.style.padding = '12px';
-    warningDiv.style.marginBottom = '16px';
-    warningDiv.style.backgroundColor = 'rgba(243, 156, 18, 0.1)';
-    warningDiv.style.border = '1px solid var(--warn)';
-    warningDiv.style.borderRadius = '8px';
-    warningDiv.style.color = 'var(--warn)';
+    warningDiv.className = 'markdown-warning';
     warningDiv.textContent = '⚠ Markdown rendering unavailable. Displaying raw text.';
     contentEl.appendChild(warningDiv);
 
     // Raw text fallback
     const pre = document.createElement('pre');
-    pre.style.whiteSpace = 'pre-wrap';
-    pre.style.fontFamily = 'var(--font-mono)';
+    pre.className = 'markdown-fallback';
     pre.textContent = raw;
     contentEl.appendChild(pre);
   }

--- a/src/styles/components/content.css
+++ b/src/styles/components/content.css
@@ -274,3 +274,18 @@ a:hover { text-decoration: underline; }
 /* Danger zone variations */
 .danger-title { font-size:15px; font-weight:600; color:var(--danger); margin-bottom:10px; }
 .danger-desc { font-size:13px; color:var(--muted); margin-bottom:14px; }
+
+/* Markdown fallback styles */
+.markdown-warning {
+  padding: 12px;
+  margin-bottom: 16px;
+  background-color: rgba(243, 156, 18, 0.1);
+  border: 1px solid var(--warn);
+  border-radius: 8px;
+  color: var(--warn);
+}
+
+.markdown-fallback {
+  white-space: pre-wrap;
+  font-family: var(--font-mono);
+}

--- a/src/unit-tests/modules/prompt-renderer.test.js
+++ b/src/unit-tests/modules/prompt-renderer.test.js
@@ -146,7 +146,32 @@ describe('prompt-renderer', () => {
       return null;
     });
 
-    global.document.createElement.mockReturnValue(mockElement);
+    global.document.createElement.mockImplementation(() => ({
+      innerHTML: '',
+      textContent: '',
+      style: { display: 'block' },
+      classList: {
+        add: vi.fn(),
+        remove: vi.fn(),
+        contains: vi.fn().mockReturnValue(false)
+      },
+      onclick: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      appendChild: vi.fn(),
+      removeChild: vi.fn(),
+      querySelectorAll: vi.fn().mockReturnValue([]),
+      closest: vi.fn().mockReturnValue(null),
+      href: '',
+      download: '',
+      title: '',
+      removeAttribute: vi.fn(),
+      setAttribute: vi.fn(),
+      getAttribute: vi.fn(),
+      dataset: {},
+      childNodes: [],
+      focus: vi.fn()
+    }));
   });
 
   afterEach(() => {
@@ -423,11 +448,12 @@ describe('prompt-renderer', () => {
         return null;
       });
       
-      global.document.createElement.mockReturnValue({
+      global.document.createElement.mockImplementation(() => ({
         style: {},
         textContent: '',
-        appendChild: vi.fn()
-      });
+        appendChild: vi.fn(),
+        className: ''
+      }));
       
       initPromptRenderer();
       
@@ -453,11 +479,17 @@ describe('prompt-renderer', () => {
       // Get the contentEl that was set during init
       const contentEl = global.document.getElementById('content');
       
+      // Capture appended elements
+      const appendedElements = [];
+      contentEl.appendChild.mockImplementation((el) => appendedElements.push(el));
+
       // Should not throw - error is handled gracefully with fallback UI
       await expect(selectFile(mockFile, true, 'owner', 'repo', 'main')).resolves.toBeUndefined();
       
       // Verify fallback rendering was used
-      expect(contentEl.appendChild).toHaveBeenCalled();
+      expect(appendedElements.length).toBe(2);
+      expect(appendedElements[0].className).toBe('markdown-warning');
+      expect(appendedElements[1].className).toBe('markdown-fallback');
     });
 
     it('should handle DOM manipulation errors gracefully', () => {


### PR DESCRIPTION
Refactored the markdown rendering fallback mechanism in `src/modules/prompt-renderer.js` to use CSS classes instead of inline styles. 

Changes:
- Added `.markdown-warning` and `.markdown-fallback` classes to `src/styles/components/content.css`.
- Updated `src/modules/prompt-renderer.js` to assign these classes to the warning banner and raw text fallback elements when `marked.js` fails to load or parse.
- Updated `src/unit-tests/modules/prompt-renderer.test.js` to verify that the elements have the correct classes.
- Fixed a mock issue in `prompt-renderer.test.js` where `createElement` was returning the same object instance.

Verification:
- Unit tests passed.
- Frontend verification using Playwright confirmed that the warning banner and raw text are displayed correctly when `marked.js` is blocked.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/d405aa41-d45b-40f3-99fd-4e6520e84910" />

---
*PR created automatically by Jules for task [17452725424847495317](https://jules.google.com/task/17452725424847495317) started by @dogi*