### PR TITLE
Refactor dropdown styles to use classes and variables

### DIFF
--- a/src/modules/repo-branch-selector.js
+++ b/src/modules/repo-branch-selector.js
@@ -23,6 +23,8 @@ function setupClickOutsideClose(targetBtn, targetMenu) {
   const closeDropdown = (e) => {
     if (!targetBtn.contains(e.target) && !targetMenu.contains(e.target)) {
       targetMenu.classList.remove('open');
+      targetMenu.classList.remove('dropdown-menu--open');
+      targetMenu.classList.remove('dropdown-menu--positioned');
       targetBtn.setAttribute('aria-expanded', 'false');
     }
   };
@@ -158,7 +160,8 @@ export class RepoSelector {
       e.stopPropagation();
       if (this.dropdownMenu.classList.contains('open')) {
         this.dropdownMenu.classList.remove('open');
-        this.dropdownMenu.style.display = '';
+        this.dropdownMenu.classList.remove('dropdown-menu--open');
+        this.dropdownMenu.classList.remove('dropdown-menu--positioned');
         this.dropdownBtn.setAttribute('aria-expanded', 'false');
         return;
       }
@@ -169,9 +172,10 @@ export class RepoSelector {
       const computedStyle = window.getComputedStyle(this.dropdownMenu);
       if (computedStyle.position === 'fixed') {
         const rect = this.dropdownBtn.getBoundingClientRect();
-        this.dropdownMenu.style.top = `${rect.bottom + 4}px`;
-        this.dropdownMenu.style.left = `${rect.left}px`;
-        this.dropdownMenu.style.width = `${rect.width}px`;
+        this.dropdownMenu.style.setProperty('--dropdown-top', `${rect.bottom + 4}px`);
+        this.dropdownMenu.style.setProperty('--dropdown-left', `${rect.left}px`);
+        this.dropdownMenu.style.setProperty('--dropdown-width', `${rect.width}px`);
+        this.dropdownMenu.classList.add('dropdown-menu--positioned');
       }
       
       await this.populateDropdown();
@@ -332,7 +336,8 @@ export class RepoSelector {
           this.selectedSourceId = fav.id;
           this.dropdownText.textContent = fav.name;
           this.dropdownMenu.classList.remove('open');
-          this.dropdownMenu.style.display = '';
+          this.dropdownMenu.classList.remove('dropdown-menu--open');
+          this.dropdownMenu.classList.remove('dropdown-menu--positioned');
           
           this.saveToStorage();
           this.dropdownBtn.setAttribute('aria-expanded', 'false');
@@ -380,7 +385,8 @@ export class RepoSelector {
           this.selectedSourceId = repo.id;
           this.dropdownText.textContent = repo.name;
           this.dropdownMenu.classList.remove('open');
-          this.dropdownMenu.style.display = '';
+          this.dropdownMenu.classList.remove('dropdown-menu--open');
+          this.dropdownMenu.classList.remove('dropdown-menu--positioned');
           
           this.saveToStorage();
           this.dropdownBtn.setAttribute('aria-expanded', 'false');
@@ -409,7 +415,7 @@ export class RepoSelector {
     loadingIndicator.textContent = 'Loading...';
     this.dropdownMenu.appendChild(loadingIndicator);
     this.dropdownMenu.classList.add('open');
-    this.dropdownMenu.style.display = '';
+    this.dropdownMenu.classList.add('dropdown-menu--open');
     
     await new Promise(resolve => setTimeout(resolve, 0));
     
@@ -429,7 +435,7 @@ export class RepoSelector {
     }
     
     this.dropdownMenu.classList.add('open');
-    this.dropdownMenu.style.display = '';
+    this.dropdownMenu.classList.add('dropdown-menu--open');
   }
 
   async renderFavorites() {
@@ -438,7 +444,8 @@ export class RepoSelector {
         this.selectedSourceId = fav.id;
         this.dropdownText.textContent = fav.name;
         this.dropdownMenu.classList.remove('open');
-        this.dropdownMenu.style.display = '';
+        this.dropdownMenu.classList.remove('dropdown-menu--open');
+        this.dropdownMenu.classList.remove('dropdown-menu--positioned');
         
         // Save repo selection
         this.saveToStorage();
@@ -553,7 +560,8 @@ export class RepoSelector {
         this.selectedSourceId = source.name || source.id;
         this.dropdownText.textContent = repoName;
         this.dropdownMenu.classList.remove('open');
-        this.dropdownMenu.style.display = '';
+        this.dropdownMenu.classList.remove('dropdown-menu--open');
+        this.dropdownMenu.classList.remove('dropdown-menu--positioned');
         
         // Save repo selection
         this.saveToStorage();
@@ -584,7 +592,8 @@ export class RepoSelector {
       if (isFavorite) {
         await this.removeFavorite(id);
         this.dropdownMenu.classList.remove('open');
-        this.dropdownMenu.style.display = '';
+        this.dropdownMenu.classList.remove('dropdown-menu--open');
+        this.dropdownMenu.classList.remove('dropdown-menu--positioned');
         this.dropdownBtn.setAttribute('aria-expanded', 'false');
         setTimeout(() => this.populateDropdown(), 0);
       } else {
@@ -792,7 +801,8 @@ export class BranchSelector {
       e.stopPropagation();
       if (this.dropdownMenu.classList.contains('open')) {
         this.dropdownMenu.classList.remove('open');
-        this.dropdownMenu.style.display = '';
+        this.dropdownMenu.classList.remove('dropdown-menu--open');
+        this.dropdownMenu.classList.remove('dropdown-menu--positioned');
         this.dropdownBtn.setAttribute('aria-expanded', 'false');
         return;
       }
@@ -803,9 +813,10 @@ export class BranchSelector {
       const computedStyle = window.getComputedStyle(this.dropdownMenu);
       if (computedStyle.position === 'fixed') {
         const rect = this.dropdownBtn.getBoundingClientRect();
-        this.dropdownMenu.style.top = `${rect.bottom + 4}px`;
-        this.dropdownMenu.style.left = `${rect.left}px`;
-        this.dropdownMenu.style.width = `${rect.width}px`;
+        this.dropdownMenu.style.setProperty('--dropdown-top', `${rect.bottom + 4}px`);
+        this.dropdownMenu.style.setProperty('--dropdown-left', `${rect.left}px`);
+        this.dropdownMenu.style.setProperty('--dropdown-width', `${rect.width}px`);
+        this.dropdownMenu.classList.add('dropdown-menu--positioned');
       }
       
       this.populateDropdown();
@@ -929,7 +940,8 @@ export class BranchSelector {
       currentItem.className = 'dropdown-item-with-star selected';
       currentItem.onclick = () => {
         this.dropdownMenu.classList.remove('open');
-        this.dropdownMenu.style.display = '';
+        this.dropdownMenu.classList.remove('dropdown-menu--open');
+        this.dropdownMenu.classList.remove('dropdown-menu--positioned');
         this.dropdownBtn.setAttribute('aria-expanded', 'false');
       };
       
@@ -964,7 +976,8 @@ export class BranchSelector {
       item.onclick = () => {
         this.setSelectedBranch(branch.name);
         this.dropdownMenu.classList.remove('open');
-        this.dropdownMenu.style.display = '';
+        this.dropdownMenu.classList.remove('dropdown-menu--open');
+        this.dropdownMenu.classList.remove('dropdown-menu--positioned');
         this.dropdownBtn.setAttribute('aria-expanded', 'false');
       };
       
@@ -1001,7 +1014,8 @@ export class BranchSelector {
     currentItem.className = 'dropdown-item-with-star selected';
     currentItem.onclick = () => {
       this.dropdownMenu.classList.remove('open');
-      this.dropdownMenu.style.display = '';
+      this.dropdownMenu.classList.remove('dropdown-menu--open');
+      this.dropdownMenu.classList.remove('dropdown-menu--positioned');
       this.dropdownBtn.setAttribute('aria-expanded', 'false');
     };
     
@@ -1066,7 +1080,8 @@ export class BranchSelector {
         currentItem.className = 'dropdown-item-with-star selected';
         currentItem.onclick = () => {
           this.dropdownMenu.classList.remove('open');
-          this.dropdownMenu.style.display = '';
+          this.dropdownMenu.classList.remove('dropdown-menu--open');
+          this.dropdownMenu.classList.remove('dropdown-menu--positioned');
           this.dropdownBtn.setAttribute('aria-expanded', 'false');
         };
         
@@ -1100,7 +1115,8 @@ export class BranchSelector {
           item.onclick = () => {
             this.setSelectedBranch(branch.name);
             this.dropdownMenu.classList.remove('open');
-            this.dropdownMenu.style.display = '';
+            this.dropdownMenu.classList.remove('dropdown-menu--open');
+            this.dropdownMenu.classList.remove('dropdown-menu--positioned');
             this.dropdownBtn.setAttribute('aria-expanded', 'false');
           };
           
@@ -1119,9 +1135,7 @@ export class BranchSelector {
     this.dropdownMenu.appendChild(showMoreBtn);
     
     this.dropdownMenu.classList.add('open');
-    if (this.dropdownMenu.style.display === 'none') {
-      this.dropdownMenu.style.display = '';
-    }
+    this.dropdownMenu.classList.add('dropdown-menu--open');
   }
 
   setSelectedBranch(branch) {

--- a/src/styles/components/dropdown.css
+++ b/src/styles/components/dropdown.css
@@ -70,6 +70,23 @@
   display: block;
 }
 
+/* New Dropdown State Classes */
+.dropdown-menu {
+  display: none;
+}
+
+.dropdown-menu--open {
+  display: block;
+}
+
+.dropdown-menu--positioned {
+  position: fixed;
+  top: var(--dropdown-top);
+  left: var(--dropdown-left);
+  width: var(--dropdown-width);
+  z-index: 1200;
+}
+
 /* Favorites Dropdown Item - Reusable component for star-based favorites */
 .dropdown-item-with-star {
   display: flex;
@@ -249,4 +266,3 @@
 .dropdown-search-clear.hidden {
   display: none;
 }
-

--- a/src/unit-tests/dropdown-refactor.test.js
+++ b/src/unit-tests/dropdown-refactor.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Setup global mocks
+const mockAuth = {
+  currentUser: null
+};
+
+let mockDb = {
+  collection: vi.fn()
+};
+
+// Mock firebase-service
+vi.mock('../modules/firebase-service.js', () => ({
+  getAuth: vi.fn(function() { return global.window?.auth !== undefined ? global.window.auth : mockAuth; }),
+  getDb: vi.fn(function() { return global.window?.db !== undefined ? global.window.db : mockDb; }),
+  getFunctions: vi.fn(() => null)
+}));
+
+import { RepoSelector, BranchSelector } from '../modules/repo-branch-selector.js';
+
+// Mock dependencies
+vi.mock('../utils/dom-helpers.js', () => ({
+  toggleVisibility: vi.fn()
+}));
+
+vi.mock('../modules/auth.js', () => ({
+  getCurrentUser: vi.fn()
+}));
+
+vi.mock('../modules/toast.js', () => ({
+  showToast: vi.fn()
+}));
+
+vi.mock('../utils/constants.js', () => ({
+  DEFAULT_FAVORITE_REPOS: []
+}));
+
+vi.mock('../modules/jules-api.js', () => ({
+  listJulesSources: vi.fn(),
+  getDecryptedJulesKey: vi.fn()
+}));
+
+vi.mock('../modules/github-api.js', () => ({
+  getBranches: vi.fn()
+}));
+
+vi.mock('../utils/lazy-loaders.js', () => ({
+  loadFuse: vi.fn(() => Promise.resolve(class MockFuse {
+    constructor() {}
+    search() { return []; }
+  }))
+}));
+
+// Setup global mocks
+Object.defineProperty(global, 'localStorage', {
+  value: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn()
+  },
+  writable: true
+});
+
+global.console = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  log: vi.fn()
+};
+
+global.window = {
+  auth: mockAuth,
+  db: mockDb,
+  getComputedStyle: vi.fn(() => ({ position: 'static' })),
+  firebase: {
+    firestore: {
+      FieldValue: {
+        serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP')
+      }
+    }
+  }
+};
+
+const createMockElement = (id = '') => {
+  const classList = new Set();
+  const style = {
+    setProperty: vi.fn(),
+    display: '', // We want to track this
+  };
+
+  return {
+    id,
+    textContent: '',
+    disabled: false,
+    onclick: null,
+    dataset: {},
+    classList: {
+      add: vi.fn((cls) => classList.add(cls)),
+      remove: vi.fn((cls) => classList.delete(cls)),
+      contains: vi.fn((cls) => classList.has(cls)),
+      toggle: vi.fn((cls) => {
+        if (classList.has(cls)) classList.delete(cls);
+        else classList.add(cls);
+      })
+    },
+    setAttribute: vi.fn(),
+    getAttribute: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    style,
+    appendChild: vi.fn(),
+    innerHTML: '',
+    contains: vi.fn(() => false),
+    getBoundingClientRect: vi.fn(() => ({
+      top: 100,
+      bottom: 150,
+      left: 50,
+      right: 250,
+      width: 200
+    })),
+    querySelector: vi.fn(() => null),
+    querySelectorAll: vi.fn(() => [])
+  };
+};
+
+global.document = {
+  createElement: vi.fn((tag) => createMockElement(tag)),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn()
+};
+
+describe('Dropdown Refactor Tests', () => {
+  let repoSelector;
+  let mockBtn, mockText, mockMenu;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Set default computed style
+    global.window.getComputedStyle.mockReturnValue({ position: 'static' });
+
+    mockBtn = createMockElement('repoBtn');
+    mockText = createMockElement('repoText');
+    mockMenu = createMockElement('repoMenu');
+
+    const { getCurrentUser } = await import('../modules/auth.js');
+    getCurrentUser.mockReturnValue({ uid: 'user123', email: 'test@example.com' });
+
+    // Mock API
+    const { getDecryptedJulesKey, listJulesSources } = await import('../modules/jules-api.js');
+    getDecryptedJulesKey.mockResolvedValue('mock-api-key');
+    listJulesSources.mockResolvedValue({ sources: [{ name: 'repo1' }], nextPageToken: null });
+
+    repoSelector = new RepoSelector({
+      dropdownBtn: mockBtn,
+      dropdownText: mockText,
+      dropdownMenu: mockMenu,
+      onSelect: vi.fn(),
+      showFavorites: true
+    });
+
+    await repoSelector.initialize();
+  });
+
+  it('should toggle .dropdown-menu--open class instead of modifying display', async () => {
+    // Initial state: not open
+    expect(mockMenu.classList.contains('dropdown-menu--open')).toBe(false);
+
+    // Click to open
+    await mockBtn.onclick({ stopPropagation: vi.fn() });
+
+    expect(mockMenu.classList.contains('dropdown-menu--open')).toBe(true);
+    // Ensure display style is NOT set (it should remain default/empty in our mock if untouched)
+    // Note: createMockElement initally has display: ''
+    expect(mockMenu.style.display).toBe('');
+
+    // Set open manually to simulate state for closing
+    mockMenu.classList.add('open'); // Existing logic uses this check
+
+    // Click to close
+    await mockBtn.onclick({ stopPropagation: vi.fn() });
+
+    expect(mockMenu.classList.contains('dropdown-menu--open')).toBe(false);
+  });
+
+  it('should use CSS variables for positioning when fixed', async () => {
+    global.window.getComputedStyle.mockReturnValue({ position: 'fixed' });
+
+    // Click to open
+    await mockBtn.onclick({ stopPropagation: vi.fn() });
+
+    expect(mockMenu.style.setProperty).toHaveBeenCalledWith('--dropdown-top', '154px');
+    expect(mockMenu.style.setProperty).toHaveBeenCalledWith('--dropdown-left', '50px');
+    expect(mockMenu.style.setProperty).toHaveBeenCalledWith('--dropdown-width', '200px');
+    expect(mockMenu.classList.contains('dropdown-menu--positioned')).toBe(true);
+  });
+
+  it('should remove positioning classes when closed', async () => {
+    mockMenu.classList.add('open');
+    mockMenu.classList.add('dropdown-menu--open');
+    mockMenu.classList.add('dropdown-menu--positioned');
+
+    await mockBtn.onclick({ stopPropagation: vi.fn() });
+
+    expect(mockMenu.classList.contains('dropdown-menu--positioned')).toBe(false);
+    expect(mockMenu.classList.contains('dropdown-menu--open')).toBe(false);
+  });
+});

--- a/src/unit-tests/modules/repo-branch-selector.test.js
+++ b/src/unit-tests/modules/repo-branch-selector.test.js
@@ -100,6 +100,7 @@ global.document = {
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
     style: {
+      setProperty: vi.fn(),
       cssText: '',
       display: '',
       padding: '',
@@ -164,6 +165,7 @@ const createMockElement = (id = '') => ({
   setAttribute: vi.fn(),
   getAttribute: vi.fn(),
   style: {
+    setProperty: vi.fn(),
     display: '',
     opacity: '',
     cursor: '',
@@ -441,9 +443,9 @@ describe('repo-branch-selector', () => {
         
         await mockBtn.onclick({ stopPropagation: vi.fn() });
         
-        expect(mockMenu.style.top).toBe('154px'); // 150 + 4
-        expect(mockMenu.style.left).toBe('50px');
-        expect(mockMenu.style.width).toBe('200px');
+        expect(mockMenu.style.setProperty).toHaveBeenCalledWith('--dropdown-top', '154px');
+        expect(mockMenu.style.setProperty).toHaveBeenCalledWith('--dropdown-left', '50px');
+        expect(mockMenu.style.setProperty).toHaveBeenCalledWith('--dropdown-width', '200px');
       });
 
       it('should setup click-outside handler', async () => {
@@ -755,9 +757,9 @@ describe('repo-branch-selector', () => {
         
         mockBtn.onclick({ stopPropagation: vi.fn() });
         
-        expect(mockMenu.style.top).toBe('154px');
-        expect(mockMenu.style.left).toBe('50px');
-        expect(mockMenu.style.width).toBe('200px');
+        expect(mockMenu.style.setProperty).toHaveBeenCalledWith('--dropdown-top', '154px');
+        expect(mockMenu.style.setProperty).toHaveBeenCalledWith('--dropdown-left', '50px');
+        expect(mockMenu.style.setProperty).toHaveBeenCalledWith('--dropdown-width', '200px');
       });
     });
 


### PR DESCRIPTION
Refactored `RepoSelector` and `BranchSelector` in `src/modules/repo-branch-selector.js` to avoid direct `style.display` and style property assignments.
Introduced `.dropdown-menu--open` and `.dropdown-menu--positioned` classes in `src/styles/components/dropdown.css`.
Added CSS variables `--dropdown-top`, `--dropdown-left`, `--dropdown-width` for dynamic positioning.
Updated existing unit tests and added a new test file `src/unit-tests/dropdown-refactor.test.js` to cover the changes.

---
*PR created automatically by Jules for task [4990308170676073708](https://jules.google.com/task/4990308170676073708) started by @dogi*