### PR TITLE
Refactor mobile menu scroll lock to use CSS class

### DIFF
--- a/src/modules/header.js
+++ b/src/modules/header.js
@@ -34,14 +34,14 @@ export async function loadHeader() {
       const openSidebar = () => {
         mobileSidebar.classList.add('open');
         mobileOverlay.classList.add('show');
-        document.body.style.overflow = 'hidden';
+        document.body.classList.add('mobile-menu-open');
         mobileSidebarClose.focus();
       };
       
       const closeSidebar = () => {
         mobileSidebar.classList.remove('open');
         mobileOverlay.classList.remove('show');
-        document.body.style.overflow = '';
+        document.body.classList.remove('mobile-menu-open');
         mobileMenuBtn.focus();
       };
       

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -170,3 +170,7 @@ html, body {
 .modal-hide {
   display: none !important;
 }
+
+.mobile-menu-open {
+  overflow: hidden;
+}

--- a/src/unit-tests/modules/header.test.js
+++ b/src/unit-tests/modules/header.test.js
@@ -177,7 +177,7 @@ describe('header', () => {
       
       expect(mobileSidebar.classList.contains('open')).toBe(true);
       expect(mobileOverlay.classList.contains('show')).toBe(true);
-      expect(document.body.style.overflow).toBe('hidden');
+      expect(document.body.classList.contains('mobile-menu-open')).toBe(true);
     });
 
     it('should close mobile sidebar when close button is clicked', () => {
@@ -189,7 +189,7 @@ describe('header', () => {
       
       expect(mobileSidebar.classList.contains('open')).toBe(false);
       expect(mobileOverlay.classList.contains('show')).toBe(false);
-      expect(document.body.style.overflow).toBe('');
+      expect(document.body.classList.contains('mobile-menu-open')).toBe(false);
     });
 
     it('should close mobile sidebar when overlay is clicked', () => {
@@ -400,13 +400,13 @@ describe('header', () => {
       mobileMenuBtn.click();
       expect(mobileSidebar.classList.contains('open')).toBe(true);
       expect(mobileOverlay.classList.contains('show')).toBe(true);
-      expect(document.body.style.overflow).toBe('hidden');
+      expect(document.body.classList.contains('mobile-menu-open')).toBe(true);
       
       // Close via overlay
       mobileOverlay.click();
       expect(mobileSidebar.classList.contains('open')).toBe(false);
       expect(mobileOverlay.classList.contains('show')).toBe(false);
-      expect(document.body.style.overflow).toBe('');
+      expect(document.body.classList.contains('mobile-menu-open')).toBe(false);
     });
 
     it('should initialize all components when header loads successfully', async () => {


### PR DESCRIPTION
Consolidates state management for the mobile menu scroll lock by moving the `overflow: hidden` style to a CSS class `.mobile-menu-open` in `base.css`. This improves maintainability and separation of concerns. The `header.js` module now toggles this class instead of manipulating the `style` attribute directly. Unit tests were updated to reflect this change. verified via Playwright.

---
*PR created automatically by Jules for task [2703643022681867004](https://jules.google.com/task/2703643022681867004) started by @dogi*