### PR TITLE
smoother footer on-hover effects (fixes #582)

### DIFF
--- a/src/styles/components/footer.css
+++ b/src/styles/components/footer.css
@@ -4,5 +4,6 @@ footer code { background: #0b0f21; padding: 1px 4px; border-radius: 4px; font-si
 
 /* Footer navigation */
 .footer-nav { text-align: center; }
-.footer-nav__item { color: var(--muted); text-decoration: none; background: none; border: none; cursor: pointer; font: inherit; padding: 0; }
+.footer-nav__item { color: var(--muted); text-decoration: none; background: none; border: none; cursor: pointer; font: inherit; padding: 0; transition: color 0.2s ease; }
+.footer-nav__item:hover { color: var(--accent); text-decoration: underline; }
 .footer-nav__sep { margin: 0 12px; }


### PR DESCRIPTION
All footer items now have consistent on-hover effects. 

<img width="1006" height="213" alt="image" src="https://github.com/user-attachments/assets/79d13b5b-1032-4ef5-a900-ab3bc74d8c58" />
