### PR TITLE
Fix CSP to allow apis.google.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.gstatic.com; connect-src 'self' https://api.github.com https://jules.googleapis.com https://*.googleapis.com https://*.firebaseio.com https://runjuleshttp-fjbc67s6eq-uc.a.run.app https://raw.githubusercontent.com https://gist.githubusercontent.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.gstatic.com https://apis.google.com; connect-src 'self' https://api.github.com https://jules.googleapis.com https://*.googleapis.com https://*.firebaseio.com https://runjuleshttp-fjbc67s6eq-uc.a.run.app https://raw.githubusercontent.com https://gist.githubusercontent.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com" />
   <title>PromptRoot</title>
   <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
   


### PR DESCRIPTION
Added https://apis.google.com to the script-src directive in index.html to fix a Content Security Policy violation that prevented Firebase Auth from loading the Google API client script.

---
*PR created automatically by Jules for task [7407032221022058705](https://jules.google.com/task/7407032221022058705) started by @dogi*