### PR TITLE
Remove unused setElementDisplay function

### DIFF
--- a/docs/CODE_STYLE_GUIDE.md
+++ b/docs/CODE_STYLE_GUIDE.md
@@ -221,7 +221,6 @@ Located in `src/utils/dom-helpers.js`:
 ```javascript
 import { 
   createElement, 
-  setElementDisplay, 
   toggleClass, 
   clearElement, 
   onElement,
@@ -235,12 +234,6 @@ import {
 ```javascript
 const div = createElement('div', 'my-class', 'Text content');
 const button = createElement('button', 'btn primary');
-```
-
-**setElementDisplay(element, show)**
-```javascript
-setElementDisplay(element, true);  // Show
-setElementDisplay(element, false); // Hide
 ```
 
 **toggleClass(element, className, force)**
@@ -279,14 +272,6 @@ onElement(badge, 'click', (e) => {
 element.classList.add('hidden');      // Hide
 element.classList.remove('hidden');   // Show
 element.classList.toggle('hidden');   // Toggle
-```
-
-### Use Helper When Appropriate
-
-```javascript
-// ✅ Good: Helper function
-import { setElementDisplay } from '../utils/dom-helpers.js';
-setElementDisplay(element, isVisible);
 ```
 
 ### Avoid Direct Style Manipulation

--- a/src/tests/modules/prompt-renderer.test.js
+++ b/src/tests/modules/prompt-renderer.test.js
@@ -32,7 +32,6 @@ vi.mock('../../utils/constants.js', () => ({
 }));
 
 vi.mock('../../utils/dom-helpers.js', () => ({
-  setElementDisplay: vi.fn(),
   toggleVisibility: vi.fn()
 }));
 

--- a/src/unit-tests/modules/prompt-list.test.js
+++ b/src/unit-tests/modules/prompt-list.test.js
@@ -78,7 +78,6 @@ vi.mock('../../utils/dom-helpers.js', () => {
   return {
     clearElement: vi.fn(),
     stopPropagation: vi.fn(),
-    setElementDisplay: vi.fn(),
     toggleClass: vi.fn(),
     createElement: createElementFn
   };

--- a/src/unit-tests/modules/prompt-renderer-hardening.test.js
+++ b/src/unit-tests/modules/prompt-renderer-hardening.test.js
@@ -20,7 +20,6 @@ vi.mock('../../utils/constants.js', () => ({
 }));
 
 vi.mock('../../utils/dom-helpers.js', () => ({
-  setElementDisplay: vi.fn(),
   toggleVisibility: vi.fn()
 }));
 

--- a/src/unit-tests/modules/prompt-renderer.test.js
+++ b/src/unit-tests/modules/prompt-renderer.test.js
@@ -32,7 +32,6 @@ vi.mock('../../utils/constants.js', () => ({
 }));
 
 vi.mock('../../utils/dom-helpers.js', () => ({
-  setElementDisplay: vi.fn(),
   toggleVisibility: vi.fn()
 }));
 

--- a/src/unit-tests/utils/dom-helpers.test.js
+++ b/src/unit-tests/utils/dom-helpers.test.js
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { 
   createElement, 
   createIcon, 
-  setElementDisplay,
   toggleVisibility,
   toggleClass, 
   clearElement
@@ -118,47 +117,6 @@ describe('DOM Helpers', () => {
       const icon = createIcon('default');
       
       expect(icon.getAttribute('aria-hidden')).toBe('true');
-    });
-  });
-
-  describe('setElementDisplay', () => {
-    it('should show element by default', () => {
-      const el = document.createElement('div');
-      el.classList.add('hidden');
-      
-      setElementDisplay(el);
-      
-      expect(el.classList.contains('hidden')).toBe(false);
-    });
-
-    it('should show element when show=true', () => {
-      const el = document.createElement('div');
-      el.classList.add('hidden');
-      
-      setElementDisplay(el, true);
-      
-      expect(el.classList.contains('hidden')).toBe(false);
-    });
-
-    it('should hide element when show=false', () => {
-      const el = document.createElement('div');
-      
-      setElementDisplay(el, false);
-      
-      expect(el.classList.contains('hidden')).toBe(true);
-    });
-
-    it('should toggle visibility correctly', () => {
-      const el = document.createElement('div');
-      
-      setElementDisplay(el, false);
-      expect(el.classList.contains('hidden')).toBe(true);
-      
-      setElementDisplay(el, true);
-      expect(el.classList.contains('hidden')).toBe(false);
-      
-      setElementDisplay(el, false);
-      expect(el.classList.contains('hidden')).toBe(true);
     });
   });
 

--- a/src/utils/dom-helpers.js
+++ b/src/utils/dom-helpers.js
@@ -29,10 +29,6 @@ export function toggleVisibility(element, shouldShow = true) {
   element.style.display = '';
 }
 
-export function setElementDisplay(el, show = true) {
-  toggleVisibility(el, show);
-}
-
 export function toggleClass(el, className, force) {
   if (force === undefined) {
     el.classList.toggle(className);


### PR DESCRIPTION
Removed unused `setElementDisplay` function from `src/utils/dom-helpers.js` and associated tests, mocks, and documentation. Verified that no regressions were introduced by running the full test suite.

---
*PR created automatically by Jules for task [4712139230241087586](https://jules.google.com/task/4712139230241087586) started by @dogi*