### PR TITLE
refactor: remove unused CSS classes

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -150,10 +150,6 @@ html, body {
 }
 
 /* Display utilities */
-.d-block {
-  display: block !important;
-}
-
 .d-none {
   display: none !important;
 }
@@ -163,14 +159,6 @@ html, body {
 }
 
 /* Modal utilities */
-.modal-show {
-  display: flex !important;
-}
-
-.modal-hide {
-  display: none !important;
-}
-
 .mobile-menu-open {
   overflow: hidden;
 }

--- a/src/styles/components/utilities.css
+++ b/src/styles/components/utilities.css
@@ -2,7 +2,6 @@
 /* Additional utility classes for common patterns and layouts */
 
 /* Display */
-.d-block { display: block !important; }
 .d-none { display: none !important; }
 .d-flex { display: flex !important; }
 .d-flex-center { display: flex; align-items: center; }
@@ -57,10 +56,6 @@
 
 /* Cursor */
 .cursor-pointer { cursor: pointer; }
-
-/* Modal States */
-.modal-show { display: flex !important; }
-.modal-hide { display: none !important; }
 
 /* Component-Specific Utilities */
 .label-flex {


### PR DESCRIPTION
Removed unused CSS utility classes `.d-block`, `.modal-show`, and `.modal-hide` from `src/styles/base.css` and `src/styles/components/utilities.css`. These classes were identified as unused in the codebase (excluding definition) and their removal was verified to not cause regressions in the application's critical paths using Playwright e2e smoke tests.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/1bd05d85-b75d-4ec5-b490-c0c8e127844b" />

---
*PR created automatically by Jules for task [13082035614067961349](https://jules.google.com/task/13082035614067961349) started by @dogi*