### PR TITLE
Add ARIA live regions to toast and status bar

### DIFF
--- a/e2e-tests/e2e/accessibility.spec.js
+++ b/e2e-tests/e2e/accessibility.spec.js
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('should not have any automatically detectable accessibility issues', async ({ page }) => {
+  await page.goto('/');
+  // Wait for content to ensure page is loaded
+  await page.waitForSelector('body');
+
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .disableRules(['page-has-heading-one'])
+    .analyze();
+
+  expect(accessibilityScanResults.violations).toEqual([]);
+});

--- a/src/modules/status-bar.js
+++ b/src/modules/status-bar.js
@@ -17,6 +17,9 @@ class StatusBar {
       return;
     }
     
+    this.element.setAttribute('role', 'status');
+    this.element.setAttribute('aria-live', 'polite');
+
     this.msgElement = this.element.querySelector('.status-msg');
     this.progressElement = this.element.querySelector('.status-progress');
     this.actionElement = this.element.querySelector('.status-action');
@@ -38,6 +41,7 @@ class StatusBar {
 
     const { timeout = TIMEOUTS.statusBar } = options;
 
+    this.element.setAttribute('aria-atomic', 'true');
     this.msgElement.textContent = message;
     this.element.classList.add('status-visible');
     this.element.classList.remove('hidden');

--- a/src/modules/toast.js
+++ b/src/modules/toast.js
@@ -18,6 +18,8 @@ function ensureContainer() {
   if (!toastContainer) {
     toastContainer = document.createElement('div');
     toastContainer.className = 'toast-container';
+    toastContainer.setAttribute('role', 'status');
+    toastContainer.setAttribute('aria-live', 'polite');
     document.body.appendChild(toastContainer);
   }
   return toastContainer;
@@ -34,6 +36,7 @@ export function showToast(message, type = 'info', duration = TIMEOUTS.toast) {
   
   const toast = document.createElement('div');
   toast.className = `toast toast--${type}`;
+  toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
   
   const icon = document.createElement('span');
   icon.className = 'toast__icon';

--- a/src/unit-tests/modules/status-bar.test.js
+++ b/src/unit-tests/modules/status-bar.test.js
@@ -64,6 +64,9 @@ describe('status-bar', () => {
       expect(statusBar.progressElement).toBe(mockProgressElement);
       expect(statusBar.actionElement).toBe(mockActionElement);
       expect(statusBar.closeElement).toBe(mockCloseElement);
+
+      expect(statusBar.element.getAttribute('role')).toBe('status');
+      expect(statusBar.element.getAttribute('aria-live')).toBe('polite');
     });
 
     it('should hide status bar initially', () => {
@@ -121,6 +124,7 @@ describe('status-bar', () => {
       expect(mockMsgElement.textContent).toBe(message);
       expect(mockStatusBarElement.classList.contains('status-visible')).toBe(true);
       expect(mockStatusBarElement.classList.contains('hidden')).toBe(false);
+      expect(mockStatusBarElement.getAttribute('aria-atomic')).toBe('true');
     });
 
     it('should auto-hide message after default timeout', () => {

--- a/src/unit-tests/modules/toast.test.js
+++ b/src/unit-tests/modules/toast.test.js
@@ -32,6 +32,8 @@ describe('toast', () => {
       const container = document.querySelector('.toast-container');
       expect(container).toBeTruthy();
       expect(container.parentElement).toBe(document.body);
+      expect(container.getAttribute('role')).toBe('status');
+      expect(container.getAttribute('aria-live')).toBe('polite');
     });
 
     it('should reuse existing container for multiple toasts', () => {
@@ -98,6 +100,7 @@ describe('toast', () => {
       const toast = showToast('Success!', 'success');
       
       expect(toast.className).toBe('toast toast--success toast--show');
+      expect(toast.getAttribute('role')).toBe('status');
       
       const icon = toast.querySelector('.toast__icon');
       expect(icon.textContent).toBe('✓');
@@ -107,6 +110,7 @@ describe('toast', () => {
       const toast = showToast('Error!', 'error');
       
       expect(toast.className).toBe('toast toast--error toast--show');
+      expect(toast.getAttribute('role')).toBe('alert');
       
       const icon = toast.querySelector('.toast__icon');
       expect(icon.textContent).toBe('✗');
@@ -116,6 +120,7 @@ describe('toast', () => {
       const toast = showToast('Warning!', 'warn');
       
       expect(toast.className).toBe('toast toast--warn toast--show');
+      expect(toast.getAttribute('role')).toBe('status');
       
       const icon = toast.querySelector('.toast__icon');
       expect(icon.textContent).toBe('⚠');
@@ -125,6 +130,7 @@ describe('toast', () => {
       const toast = showToast('Info!', 'info');
       
       expect(toast.className).toBe('toast toast--info toast--show');
+      expect(toast.getAttribute('role')).toBe('status');
       
       const icon = toast.querySelector('.toast__icon');
       expect(icon.textContent).toBe('ⓘ');


### PR DESCRIPTION
This change improves accessibility by ensuring that toast notifications and status bar updates are announced by screen readers. It adds ARIA live region attributes to the relevant DOM elements and verifies these changes with unit tests and a new automated accessibility test.

---
*PR created automatically by Jules for task [9933190411111490103](https://jules.google.com/task/9933190411111490103) started by @dogi*