### PR TITLE
Refactor modal CSS to BEM selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
   </div>
 
   <!-- Jules API Key Modal -->
-  <div id="julesKeyModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="julesKeyModalTitle">
+  <div id="julesKeyModal" class="modal modal--jules-key" role="dialog" aria-modal="true" aria-labelledby="julesKeyModalTitle">
     <div class="modal-content">
       <h2 id="julesKeyModalTitle">Save Jules API Key</h2>
       <p>Enter your Jules API key. This will be encrypted and stored securely.</p>
@@ -167,7 +167,7 @@
         <div class="form-row">
           <!-- Repository Selection -->
           <div class="form-col">
-            <label class="form-label">Repository:</label>
+            <label class="modal__form-label">Repository:</label>
             <div id="julesRepoDropdown" class="custom-dropdown">
               <button id="julesRepoDropdownBtn" class="custom-dropdown-btn w-full" type="button">
                 <span id="julesRepoDropdownText">Select a repository...</span>
@@ -179,7 +179,7 @@
           
           <!-- Branch Selection -->
           <div class="form-col">
-            <label class="form-label">Branch:</label>
+            <label class="modal__form-label">Branch:</label>
             <div id="julesBranchDropdown" class="custom-dropdown">
               <button id="julesBranchDropdownBtn" class="custom-dropdown-btn w-full" type="button" disabled>
                 <span id="julesBranchDropdownText">Select branch...</span>
@@ -192,8 +192,8 @@
       </div>
       
       <div class="options-box">
-        <label class="form-label small-text"><input type="checkbox" id="julesEnvSuppressPopupsCheckbox" data-exclusive-group="jules-env" /> Suppress Popups</label>
-        <label class="form-label small-text"><input type="checkbox" id="julesEnvOpenInBackgroundCheckbox" data-exclusive-group="jules-env" /> Open in Background</label>
+        <label class="modal__form-label small-text"><input type="checkbox" id="julesEnvSuppressPopupsCheckbox" data-exclusive-group="jules-env" /> Suppress Popups</label>
+        <label class="modal__form-label small-text"><input type="checkbox" id="julesEnvOpenInBackgroundCheckbox" data-exclusive-group="jules-env" /> Open in Background</label>
       </div>
       
       <div class="modal-buttons">
@@ -235,7 +235,7 @@
   </div>
 
   <!-- Subtask Preview Modal -->
-  <div id="subtaskPreviewModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="subtaskPreviewTitle">
+  <div id="subtaskPreviewModal" class="modal modal--subtask-preview" role="dialog" aria-modal="true" aria-labelledby="subtaskPreviewTitle">
     <div class="modal-content modal-xl">
       <h2 id="subtaskPreviewTitle">Subtask Preview</h2>
       <div id="subtaskPreviewContent" class="scroll-box"></div>

--- a/pages/profile/profile.html
+++ b/pages/profile/profile.html
@@ -96,12 +96,12 @@
         </button>
       </div>
       <div class="modal-body">
-        <div class="form-group">
-          <label class="form-label" for="copenLabel">Label</label>
+        <div class="modal__form-group">
+          <label class="modal__form-label" for="copenLabel">Label</label>
           <input type="text" id="copenLabel" class="form-control" placeholder="e.g., My AI Tool" required>
         </div>
-        <div class="form-group">
-          <label class="form-label" for="copenUrl">URL</label>
+        <div class="modal__form-group">
+          <label class="modal__form-label" for="copenUrl">URL</label>
           <input type="url" id="copenUrl" class="form-control" placeholder="https://example.com" required>
         </div>
       </div>
@@ -113,7 +113,7 @@
   </div>
 
   <!-- Jules API Key Modal -->
-  <div id="julesKeyModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="julesKeyModalTitle">
+  <div id="julesKeyModal" class="modal modal--jules-key" role="dialog" aria-modal="true" aria-labelledby="julesKeyModalTitle">
     <div class="modal-content">
       <h2 id="julesKeyModalTitle">Save Jules API Key</h2>
       <p>Enter your Jules API key. This will be encrypted and stored securely.</p>

--- a/partials/schedule-queue-modal.html
+++ b/partials/schedule-queue-modal.html
@@ -8,20 +8,20 @@
     </div>
     <div class="modal-body">
       <p class="form-help-text">Schedule selected items to run automatically at a specific time.</p>
-      <div class="form-group">
-        <label class="form-label" for="scheduleDate">Date:</label>
+      <div class="modal__form-group">
+        <label class="modal__form-label" for="scheduleDate">Date:</label>
         <input type="date" id="scheduleDate" class="form-control" required />
       </div>
-      <div class="form-group">
-        <label class="form-label" for="scheduleTime">Time:</label>
+      <div class="modal__form-group">
+        <label class="modal__form-label" for="scheduleTime">Time:</label>
         <input type="time" id="scheduleTime" class="form-control" required />
       </div>
-      <div class="form-group">
-        <label class="form-label" for="scheduleTimeZone">Time Zone:</label>
+      <div class="modal__form-group">
+        <label class="modal__form-label" for="scheduleTimeZone">Time Zone:</label>
         <select id="scheduleTimeZone" class="form-control"></select>
       </div>
-      <div class="form-group">
-        <label class="form-label">
+      <div class="modal__form-group">
+        <label class="modal__form-label">
           <input type="checkbox" id="scheduleRetryOnFailure" />
           Retry on failure (every 10 minutes, max 3 attempts)
         </label>

--- a/src/modules/confirm-modal.js
+++ b/src/modules/confirm-modal.js
@@ -8,7 +8,7 @@ import { createModal } from '../utils/modal-manager.js';
 let activeConfirmModal = null;
 
 function buildConfirmModalDOM() {
-  const modal = createElement('div', 'modal');
+  const modal = createElement('div', 'modal modal--confirm');
   modal.id = 'confirmModal';
   modal.setAttribute('role', 'dialog');
   modal.setAttribute('aria-modal', 'true');

--- a/src/modules/jules-queue.js
+++ b/src/modules/jules-queue.js
@@ -293,7 +293,7 @@ async function openEditQueueModal(docId) {
 
   const modal = document.createElement('div');
   modal.id = 'editQueueItemModal';
-  modal.className = 'modal-overlay';
+  modal.className = 'modal-overlay modal--edit-queue';
 
   modal.setAttribute('role', 'dialog');
   modal.setAttribute('aria-modal', 'true');
@@ -327,7 +327,7 @@ async function openEditQueueModal(docId) {
 
   // Type field
   const typeGroup = document.createElement('div');
-  typeGroup.className = 'form-group';
+  typeGroup.className = 'modal__form-group';
   const typeLabel = document.createElement('label');
   typeLabel.className = 'form-section-label';
   typeLabel.textContent = 'Type:';
@@ -338,7 +338,7 @@ async function openEditQueueModal(docId) {
 
   // Schedule info
   const scheduleGroup = document.createElement('div');
-  scheduleGroup.className = 'form-group hidden';
+  scheduleGroup.className = 'modal__form-group hidden';
   scheduleGroup.id = 'editQueueStatusGroup';
   const scheduleLabel = document.createElement('label');
   scheduleLabel.className = 'form-section-label';
@@ -358,7 +358,7 @@ async function openEditQueueModal(docId) {
 
   // Prompt field
   const promptGroup = document.createElement('div');
-  promptGroup.className = 'form-group';
+  promptGroup.className = 'modal__form-group';
   promptGroup.id = 'editPromptGroup';
   const promptHeader = document.createElement('div');
   promptHeader.className = 'form-group-header';
@@ -379,7 +379,7 @@ async function openEditQueueModal(docId) {
 
   // Subtasks field
   const subtasksGroup = document.createElement('div');
-  subtasksGroup.className = 'form-group hidden';
+  subtasksGroup.className = 'modal__form-group hidden';
   subtasksGroup.id = 'editSubtasksGroup';
   const subtasksHeader = document.createElement('div');
   subtasksHeader.className = 'form-group-header';
@@ -398,7 +398,7 @@ async function openEditQueueModal(docId) {
 
   // Repository field
   const repoGroup = document.createElement('div');
-  repoGroup.className = 'form-group';
+  repoGroup.className = 'modal__form-group';
   const repoLabel = document.createElement('label');
   repoLabel.className = 'form-section-label';
   repoLabel.textContent = 'Repository:';
@@ -426,7 +426,7 @@ async function openEditQueueModal(docId) {
 
   // Branch field
   const branchGroup = document.createElement('div');
-  branchGroup.className = 'form-group space-below';
+  branchGroup.className = 'modal__form-group space-below';
   const branchLabel = document.createElement('label');
   branchLabel.className = 'form-section-label';
   branchLabel.textContent = 'Branch:';
@@ -630,14 +630,14 @@ function renderSubtasksList(subtasks) {
   
   subtasks.forEach((subtask, index) => {
     const container = document.createElement('div');
-    container.className = 'form-group subtask-item';
+    container.className = 'modal__form-group subtask-item';
     container.dataset.index = index;
     
     const header = document.createElement('div');
     header.className = 'subtask-item-header';
     
     const label = document.createElement('label');
-    label.className = 'form-label';
+    label.className = 'modal__form-label';
     label.textContent = `Subtask ${index + 1}:`;
     
     const removeBtn = document.createElement('button');

--- a/src/modules/prompt-viewer.js
+++ b/src/modules/prompt-viewer.js
@@ -11,7 +11,7 @@ let currentEscapeHandler = null;
 let promptViewerHandlers = new Map();
 
 function createPromptViewerModal() {
-  const modal = createElement('div', 'modal');
+  const modal = createElement('div', 'modal modal--prompt-viewer');
   modal.id = 'promptViewerModal';
 
   const content = createElement('div', 'modal-content modal-xl');

--- a/src/styles/components/modals.css
+++ b/src/styles/components/modals.css
@@ -1,9 +1,9 @@
 /* Modals & Jules Key Modal */
-#julesKeyModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1000; display: none !important; align-items: center; justify-content: center; }
-#julesKeyModal.show { display: flex !important; }
-#julesKeyModal > div { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; max-width: 400px; width: 90%; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); }
-#julesKeyModal h2 { margin: 0 0 12px; font-size: 18px; }
-#julesKeyModal p { margin: 0 0 16px; color: var(--muted); font-size: 13px; }
+.modal--jules-key { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1000; display: none !important; align-items: center; justify-content: center; }
+.modal--jules-key.show { display: flex !important; }
+.modal--jules-key > div { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; max-width: 400px; width: 90%; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); }
+.modal--jules-key h2 { margin: 0 0 12px; font-size: 18px; }
+.modal--jules-key p { margin: 0 0 16px; color: var(--muted); font-size: 13px; }
 #julesKeyInput { width: 100%; padding: 10px 12px; border: 1px solid var(--border); border-radius: 8px; background: #12162a; color: var(--text); outline: none; margin-bottom: 16px; box-sizing: border-box; font-size: 14px; }
 #julesKeyInput::placeholder { color: var(--muted); }
 .modal-buttons { display: flex; gap: 8px; justify-content: flex-end; }
@@ -12,15 +12,15 @@
 .modal.show { display: flex !important; }
 
 /* User Profile Modal specific */
-#userProfileModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1001; display: none; flex-direction: column; align-items: center; justify-content: center; overflow-y: auto; padding: 20px; }
-#userProfileModal.show { display: flex !important; }
+.modal--user-profile { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1001; display: none; flex-direction: column; align-items: center; justify-content: center; overflow-y: auto; padding: 20px; }
+.modal--user-profile.show { display: flex !important; }
 
 /* All Sessions Modal specific */
-#allSessionsModal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1002; display: none; flex-direction: column; align-items: center; justify-content: center; overflow-y: auto; padding: 20px; }
-#allSessionsModal.show { display: flex !important; }
+.modal--all-sessions { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.7); z-index: 1002; display: none; flex-direction: column; align-items: center; justify-content: center; overflow-y: auto; padding: 20px; }
+.modal--all-sessions.show { display: flex !important; }
 
 /* Edit Queue Modal specific */
-#editQueueItemModal { z-index: 1003; }
+.modal--edit-queue { z-index: 1003; }
 
 .modal-content { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; max-width: 400px; width: 90%; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); }
 .modal-content.modal-lg { max-width: 600px; max-height: 85vh; display: flex; flex-direction: column; overflow-y: auto; }
@@ -41,10 +41,10 @@
 .modal-buttons .btn.primary { border-color: var(--accent); color: var(--accent); }
 
 /* Specific modal layering */
-#subtaskPreviewModal { z-index: 1002; }
+.modal--subtask-preview { z-index: 1002; }
 
 /* Prompt viewer modal styles */
-#promptViewerModal { z-index: 10000; }
+.modal--prompt-viewer { z-index: 10000; }
 
 .prompt-viewer-text {
   white-space: pre-wrap;
@@ -75,11 +75,11 @@
 .modal-body .custom-dropdown-menu { position: fixed; }
 
 /* Form elements in modals */
-.form-group { margin-bottom: 16px; }
-.form-group.space-below { margin-bottom: 24px; }
+.modal__form-group { margin-bottom: 16px; }
+.modal__form-group.space-below { margin-bottom: 24px; }
 .form-section-label { display: block; margin-bottom: 6px; font-size: 14px; font-weight: 600; color: var(--text); text-transform: uppercase; letter-spacing: 0.5px; }
-.form-label { display: block; margin-bottom: 6px; font-size: 13px; font-weight: 500; color: var(--text); }
-.subtask-item-header .form-label { font-size: 12px; font-weight: 400; color: var(--muted); }
+.modal__form-label { display: block; margin-bottom: 6px; font-size: 13px; font-weight: 500; color: var(--text); }
+.subtask-item-header .modal__form-label { font-size: 12px; font-weight: 400; color: var(--muted); }
 .form-control { width: 100%; padding: 10px 12px; border: 1px solid var(--border); border-radius: 8px; background: #12162a; color: var(--text); outline: none; box-sizing: border-box; font-size: 14px; font-family: inherit; }
 .form-control:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(77, 217, 255, 0.1); }
 .form-control:read-only { background: #0a0d1a; color: var(--muted); cursor: not-allowed; }
@@ -92,14 +92,14 @@
 .close-modal:hover { opacity: 1; }
 
 /* Confirm modal specific styles */
-#confirmModal { z-index: 10000; }
-#confirmModal .modal-content { max-width: 480px; }
+.modal--confirm { z-index: 10000; }
+.modal--confirm .modal-content { max-width: 480px; }
 #confirmModalMessage { line-height: 1.6; white-space: pre-wrap; }
 
 /* Subtask editing */
 .subtask-item { margin-bottom: 16px; position: relative; }
 .subtask-item-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
-.subtask-item-header .form-label { margin-bottom: 0; }
+.subtask-item-header .modal__form-label { margin-bottom: 0; }
 .remove-subtask-btn { background: none; border: none; cursor: pointer; color: var(--warn); font-size: 18px; padding: 4px 8px; transition: color 0.2s; }
 .remove-subtask-btn:hover { color: var(--error); }
 .edit-subtask-content { font-family: monospace; font-size: 12px; }

--- a/src/unit-tests/modules/prompt-viewer.test.js
+++ b/src/unit-tests/modules/prompt-viewer.test.js
@@ -169,7 +169,7 @@ describe('prompt-viewer', () => {
       
       showPromptViewer('Test prompt', 'session123');
       
-      expect(createElement).toHaveBeenCalledWith('div', 'modal');
+      expect(createElement).toHaveBeenCalledWith('div', 'modal modal--prompt-viewer');
       expect(global.document.body.appendChild).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Refactored modal styling to use BEM methodology for better maintainability and encapsulation.

Changes:
1.  **CSS Refactoring:**
    - Modified `src/styles/components/modals.css` to replace ID selectors (e.g., `#julesKeyModal`) with BEM modifier classes (e.g., `.modal--jules-key`).
    - Scoped generic form classes `.form-group` and `.form-label` to `.modal__form-group` and `.modal__form-label` to avoid conflicts with global styles.

2.  **HTML Updates:**
    - Updated `index.html`, `pages/profile/profile.html`, and `partials/schedule-queue-modal.html` to include the new BEM classes and use the scoped form classes within modals.

3.  **JavaScript Updates:**
    - Updated `src/modules/jules-queue.js`, `src/modules/confirm-modal.js`, and `src/modules/prompt-viewer.js` to include the new BEM classes when dynamically creating modals.
    - Updated dynamic form element creation in `jules-queue.js` to use `.modal__form-group` and `.modal__form-label`.

4.  **Tests:**
    - Updated `src/unit-tests/modules/prompt-viewer.test.js` to expect the new `.modal--prompt-viewer` class.
    - Verified functionality with `npm run test:e2e:smoke` and `npm run test:run`.

Note: `userProfileModal` and `allSessionsModal` were found to be unused in the current codebase (referenced in legacy JS/CSS but not present in HTML), so their CSS selectors were updated to BEM but no HTML changes were possible for them.

---
*PR created automatically by Jules for task [11415845232514191891](https://jules.google.com/task/11415845232514191891) started by @dogi*