### PR TITLE
smoother copen styling (fixes #702)

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,11 +117,11 @@
       <div id="actions" class="hidden">
         <button class="btn" id="copyBtn" title="Copy the entire prompt"><span class="icon icon-inline" aria-hidden="true">content_copy</span> Copy</button>
         <div id="copenContainer" class="split-btn" title="Copy prompt and open in new tab">
-          <button class="split-btn__action" aria-label="Copy and open in selected app">
+          <button class="btn split-btn__action" aria-label="Copy and open in selected app">
             <span class="icon icon-inline" aria-hidden="true">open_in_new</span>
             <span>Copen</span>
           </button>
-          <button class="split-btn__toggle" aria-label="Select app" aria-haspopup="true" aria-expanded="false"></button>
+          <button class="btn split-btn__toggle" aria-label="Select app" aria-haspopup="true" aria-expanded="false"></button>
           <div class="split-btn__menu"></div>
         </div>
         <button class="btn" id="julesBtn" title="Try this prompt in Jules"><span class="icon icon-inline" aria-hidden="true">smart_toy</span> Try in Jules</button>


### PR DESCRIPTION
Fixed the unstyled copen button in prompt viewer

<img width="824" height="126" alt="image" src="https://github.com/user-attachments/assets/dd6f94f0-2681-4145-9b78-3c5617b14f0e" />
