### PR TITLE
smoother placeholder font color (fixes #715)

### DIFF
--- a/src/styles/components/content.css
+++ b/src/styles/components/content.css
@@ -47,7 +47,9 @@ a:hover { text-decoration: underline; }
 .form-row { display: flex; gap: 12px; align-items: start; }
 .form-col { flex: 1; }
 .form-label { display: block; margin-bottom: 8px; font-weight: 600; font-size: 14px; }
+#freeInputSection .form-label { color: var(--muted); }
 .text-input { width: 100%; min-height: 250px; padding: 12px; border: 1px solid var(--border); border-radius: 8px; background: #12162a; color: var(--text); outline: none; margin-bottom: 16px; box-sizing: border-box; resize: vertical; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, Noto Sans, Liberation Sans, Helvetica Neue, sans-serif; font-size: 14px; }
+.text-input::placeholder { color: var(--muted); }
 .options-box { display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px; padding: 8px; background: rgba(255,255,255,0.02); border-radius: 8px; }
 .actions-right { display: flex; gap: 8px; justify-content: flex-end; }
 .menu-anchor { position: relative; display: inline-block; }


### PR DESCRIPTION
Search and free input placeholders are now the same font color

<img width="902" height="338" alt="image" src="https://github.com/user-attachments/assets/57c9915b-6c0d-4a08-a486-5e35a987759f" />
