### PR TITLE
smoother webcapture page (fixes #717)

### DIFF
--- a/pages/webcapture/webcapture.html
+++ b/pages/webcapture/webcapture.html
@@ -31,9 +31,9 @@
           A browser extension that converts any webpage to clean Markdown and syncs it directly to your GitHub repository.
         </p>
         <button id="downloadExtensionBtn" class="btn primary xl fw-600">
-          <span class="icon icon-inline" aria-hidden="true">download</span> Download Extension
+          <span class="icon icon-inline" aria-hidden="true">store</span> Get Extension
         </button>
-        <p class="hero-note">Compatible with Chrome, Edge, Brave, and other Chromium browsers</p>
+        <p class="hero-note">Available in the Chrome Web Store for Chrome, Edge, Brave, and other Chromium browsers</p>
       </div>
 
       <!-- Features -->
@@ -87,24 +87,12 @@
           
           <ol class="instruction-list">
             <li class="instruction-item">
-              <strong class="instruction-strong">Download the extension</strong><br/>
-              Click the "Download Extension" button above to download the extension files
+              <strong class="instruction-strong">Open the Chrome Web Store</strong><br/>
+              Click the "Get Extension" button above to open the Chrome Web Store listing
             </li>
             <li class="instruction-item">
-              <strong class="instruction-strong">Extract the files</strong><br/>
-              Unzip the downloaded file to a location on your computer (e.g., Documents/PromptRoot-Extension)
-            </li>
-            <li class="instruction-item">
-              <strong class="instruction-strong">Open Extensions Page</strong><br/>
-              Navigate to <code class="code-inline">chrome://extensions/</code> (Chrome) or <code class="code-inline">edge://extensions/</code> (Edge) or <code class="code-inline">brave://extensions/</code> (Brave)
-            </li>
-            <li class="instruction-item">
-              <strong class="instruction-strong">Enable Developer Mode</strong><br/>
-              Toggle the "Developer mode" switch in the top-right corner
-            </li>
-            <li class="instruction-item">
-              <strong class="instruction-strong">Load the Extension</strong><br/>
-              Click "Load unpacked", navigate to the extracted folder, and select it
+              <strong class="instruction-strong">Add the extension</strong><br/>
+              Click "Add to Chrome" (or "Add extension") and confirm the prompt
             </li>
             <li class="instruction-item">
               <strong class="instruction-strong">Pin the Extension</strong> (optional)<br/>
@@ -173,7 +161,7 @@
           <div class="mb-md">
             <strong class="instruction-strong">Extension not appearing after installation?</strong>
             <p class="muted-text small-text" style="margin:4px 0 0;">
-              Make sure Developer Mode is enabled and you selected the correct folder. The folder should contain the manifest.json file.
+              Open your browser extensions page and verify "PromptRoot Web Capture" is enabled.
             </p>
           </div>
           <div class="mb-md">

--- a/src/pages/webcapture-page.js
+++ b/src/pages/webcapture-page.js
@@ -3,7 +3,7 @@
  * Handles extension download functionality and detection
  */
 
-import { TIMEOUTS } from '../utils/constants.js';
+import { TIMEOUTS, WEB_CAPTURE_EXTENSION_URL } from '../utils/constants.js';
 import { detectExtension, isChromium } from '../utils/extension-detector.js';
 
 function waitForComponents() {
@@ -19,7 +19,7 @@ async function initApp() {
     await checkExtensionStatus();
   }
 
-  // Download extension button
+  // Chrome Web Store button
   const downloadBtn = document.getElementById('downloadExtensionBtn');
   if (downloadBtn && !downloadBtn.dataset.bound) {
     downloadBtn.dataset.bound = 'true';
@@ -27,24 +27,18 @@ async function initApp() {
       try {
         downloadBtn.disabled = true;
         const originalDownloadLabel = downloadBtn.innerHTML;
-        downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">hourglass_top</span> Preparing download...';
+        downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">hourglass_top</span> Opening Chrome Web Store...';
 
-        // Download pre-built zip file
-        const a = document.createElement('a');
-        a.href = '../../browser-extension/pr-webcapture.zip';
-        a.download = 'promptroot-web-capture-extension.zip';
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
+        window.open(WEB_CAPTURE_EXTENSION_URL, '_blank', 'noopener');
 
-        downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">check_circle</span> Downloaded!';
+        downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">check_circle</span> Store opened';
         setTimeout(() => {
           downloadBtn.innerHTML = originalDownloadLabel;
           downloadBtn.disabled = false;
         }, TIMEOUTS.actionFeedback);
       } catch (error) {
-        console.error('Download failed:', error);
-        downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">error</span> Download failed';
+        console.error('Store link failed:', error);
+        downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">error</span> Unable to open store';
         setTimeout(() => {
           downloadBtn.innerHTML = originalDownloadLabel;
           downloadBtn.disabled = false;
@@ -61,7 +55,7 @@ async function checkExtensionStatus() {
   const isInstalled = await detectExtension();
 
   if (isInstalled) {
-    downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">refresh</span> Re-download Extension';
+    downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">store</span> View in Chrome Web Store';
   }
 }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -17,6 +17,8 @@ export const PLACEHOLDER_REGEX = /\{([A-Z0-9_-]+)\}/g;
 // Jules API
 export const JULES_API_BASE = "https://jules.googleapis.com/v1alpha";
 
+export const WEB_CAPTURE_EXTENSION_URL = "https://chromewebstore.google.com/detail/promptroot-web-capture/fbhilkiaigdedegnjgecdggbeknnbacg?utm_campaign=pmaxusbrand&utm_content=br3&utm_medium=ga&utm_source=bgads1";
+
 export const DEFAULT_FAVORITE_REPOS = [];
 
 export const STORAGE_KEY_FAVORITE_REPOS = "jules_favorite_repos";


### PR DESCRIPTION
Webcapture page now references the Chrome store rather than the complicated dev instructions (these can still be found in documentation)
<img width="1776" height="895" alt="image" src="https://github.com/user-attachments/assets/dbe9cb34-f61c-4686-96f4-fa61ed3b645f" />
