### PR TITLE
Remove unused STORAGE_KEY_FAVORITE_BRANCHES

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -24,8 +24,6 @@ export const STORAGE_KEY_FAVORITE_REPOS = "jules_favorite_repos";
 // Hardcoded favorite branches (always favorites for all users)
 export const HARDCODED_FAVORITE_BRANCHES = ["main", "web-captures"];
 
-export const STORAGE_KEY_FAVORITE_BRANCHES = "favorite_branches";
-
 // Tag definitions
 export const TAG_DEFINITIONS = {
   review: {


### PR DESCRIPTION
Removed `STORAGE_KEY_FAVORITE_BRANCHES` from `src/utils/constants.js` as it was unused.
Verified that all tests pass with `npm run test:run`.

---
*PR created automatically by Jules for task [10898128969626718221](https://jules.google.com/task/10898128969626718221) started by @dogi*