### PR TITLE
Internalize breakIntoParagraphs in subtask-manager

### DIFF
--- a/src/modules/subtask-manager.js
+++ b/src/modules/subtask-manager.js
@@ -81,7 +81,7 @@ export function extractNumberedTasks(text) {
   return tasks;
 }
 
-export function breakIntoParagraphs(text) {
+function breakIntoParagraphs(text) {
   const sections = [];
   const lines = text.split('\n');
   let currentSection = [];


### PR DESCRIPTION
Removes the export keyword from breakIntoParagraphs in src/modules/subtask-manager.js, making it a private helper function. Verified that subtask splitting functionality (specifically paragraph-based strategy) remains intact via existing unit tests.

---
*PR created automatically by Jules for task [15750289983061070864](https://jules.google.com/task/15750289983061070864) started by @dogi*