### PR TITLE
Remove unused GitHub API proxy configuration

### DIFF
--- a/src/modules/github-api.js
+++ b/src/modules/github-api.js
@@ -1,12 +1,6 @@
 import { getAuth } from './firebase-service.js';
 import { GIST_POINTER_REGEX, GIST_URL_REGEX, CACHE_DURATIONS } from '../utils/constants.js';
 
-let viaProxy = (url) => url;
-
-export function setViaProxy(proxyFn) {
-  viaProxy = proxyFn;
-}
-
 let rateLimitInfo = {
   remaining: null,
   limit: null,
@@ -65,7 +59,7 @@ function checkRateLimitError(res) {
 }
 
 async function fetchWithHeaders(url, headers) {
-  const res = await fetch(viaProxy(url), {
+  const res = await fetch(url, {
     cache: 'no-store',
     headers
   });
@@ -310,7 +304,7 @@ export async function resolveGistRawUrl(gistUrl) {
     return `https://gist.githubusercontent.com/${user}/${gistId}/raw/${targetFile}`;
   } else {
     const apiUrl = `https://api.github.com/gists/${gistId}`;
-    const res = await fetch(viaProxy(apiUrl));
+    const res = await fetch(apiUrl);
     if (!res.ok) {
       throw new Error(`Failed to fetch gist metadata: ${res.status}`);
     }
@@ -367,7 +361,7 @@ export async function getBranches(owner, repo) {
 
       for (let page = 1; page <= maxPages; page++) {
         const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/branches?per_page=${perPage}&page=${page}&ts=${Date.now()}`;
-        const batch = await fetchJSON(viaProxy(url));
+        const batch = await fetchJSON(url);
 
         if (!Array.isArray(batch) || batch.length === 0) {
           break;

--- a/src/unit-tests/modules/github-api.test.js
+++ b/src/unit-tests/modules/github-api.test.js
@@ -13,7 +13,6 @@ vi.mock('../../modules/firebase-service.js', () => ({
 }));
 
 import {
-  setViaProxy,
   fetchJSON,
   fetchJSONWithETag,
   listPromptsViaContents,
@@ -76,9 +75,6 @@ describe('github-api', () => {
     // Clear module caches
     clearCaches();
     
-    // Reset proxy function to default (identity function)
-    setViaProxy((url) => url);
-    
     // Mock Date.now for consistent testing
     vi.useFakeTimers();
     vi.setSystemTime(1000000);
@@ -86,41 +82,6 @@ describe('github-api', () => {
 
   afterEach(() => {
     vi.useRealTimers();
-  });
-
-  describe('setViaProxy', () => {
-    it('should set proxy function', async () => {
-      const proxyFn = vi.fn((url) => `proxied:${url}`);
-      setViaProxy(proxyFn);
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ data: 'test' })
-      });
-
-      await fetchJSON('https://api.github.com/test');
-
-      expect(proxyFn).toHaveBeenCalledWith('https://api.github.com/test');
-      expect(mockFetch).toHaveBeenCalledWith('proxied:https://api.github.com/test', expect.any(Object));
-      
-      // Reset to default for other tests
-      setViaProxy((url) => url);
-    });
-
-    it('should handle multiple proxy function changes', () => {
-      const proxy1 = (url) => `proxy1:${url}`;
-      const proxy2 = (url) => `proxy2:${url}`;
-
-      setViaProxy(proxy1);
-      setViaProxy(proxy2);
-
-      // The last one should be active - we can't directly test this without making a request
-      // so this test just verifies the function doesn't throw
-      expect(() => setViaProxy(proxy2)).not.toThrow();
-      
-      // Reset to default for other tests
-      setViaProxy((url) => url);
-    });
   });
 
   describe('fetchJSON', () => {
@@ -995,24 +956,6 @@ describe('github-api', () => {
       await expect(fetchRawFile('user', 'repo', 'main', 'file.md')).rejects.toThrow();
       await expect(fetchGistContent('https://gist.githubusercontent.com/user/abc/raw/file.md')).rejects.toThrow();
       expect(await getBranches('user', 'repo')).toEqual([]);
-    });
-
-    it('should maintain proxy settings across different API calls', async () => {
-      const proxyFn = vi.fn((url) => `proxy:${url}`);
-      setViaProxy(proxyFn);
-
-      // Mock successful responses for different API calls
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve([]),
-        headers: { get: () => null }
-      });
-
-      await fetchJSON('https://api.github.com/test1');
-      await getBranches('user', 'repo');
-
-      expect(proxyFn).toHaveBeenCalledWith('https://api.github.com/test1');
-      expect(proxyFn).toHaveBeenCalledWith('https://api.github.com/repos/user/repo/branches?per_page=100&page=1&ts=1000000');
     });
   });
 });


### PR DESCRIPTION
This change removes the deprecated and unused proxy configuration logic from `src/modules/github-api.js`. The `setViaProxy` export and internal `viaProxy` variable (which defaulted to an identity function) have been removed. All internal `fetch` calls now use the target URL directly. Unit tests have been updated to reflect this removal.

---
*PR created automatically by Jules for task [12356387299142558946](https://jules.google.com/task/12356387299142558946) started by @dogi*