### PR TITLE
Internalize showJulesSessionsHistoryModal and add verification test

### DIFF
--- a/src/modules/jules-account.js
+++ b/src/modules/jules-account.js
@@ -208,11 +208,7 @@ export function showUserProfileModal() {
   }
 }
 
-let profileHandlersAttached = false;
-
 function attachViewAllSessionsHandler() {
-  if (profileHandlersAttached) return;
-  
   const viewAllSessionsLink = document.getElementById('viewAllSessionsLink');
   if (viewAllSessionsLink) {
     viewAllSessionsLink.onclick = (e) => {
@@ -230,8 +226,6 @@ function attachViewQueueHandler() {
       showJulesQueueModal();
     };
   }
-  
-  profileHandlersAttached = true;
 }
 
 async function loadAndDisplayJulesProfile(uid) {
@@ -558,7 +552,7 @@ export function hideUserProfileModal() {
   modal.classList.remove('show');
 }
 
-export function showJulesSessionsHistoryModal() {
+function showJulesSessionsHistoryModal() {
   const modal = document.getElementById('julesSessionsHistoryModal');
   const searchInput = document.getElementById('sessionSearchInput');
   

--- a/src/unit-tests/modules/jules-account.test.js
+++ b/src/unit-tests/modules/jules-account.test.js
@@ -1,6 +1,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { showUserProfileModal, loadProfileDirectly } from '../../modules/jules-account.js';
+import * as julesApi from '../../modules/jules-api.js';
 import * as firebaseService from '../../modules/firebase-service.js';
 import * as julesKeys from '../../modules/jules-keys.js';
 import * as statusRenderer from '../../modules/status-renderer.js';
@@ -234,6 +235,33 @@ describe('jules-account.js', () => {
         }),
         expect.objectContaining({ category: 'AUTH' })
       );
+    });
+  });
+
+  describe('Sessions History Modal', () => {
+    it('should open modal and load sessions when View All link is clicked', async () => {
+      const mockSessions = { sessions: [{ name: 'sessions/123', prompt: 'test' }], nextPageToken: null };
+
+      // Use the mocked functions directly since they are from the mocked module
+      julesApi.getDecryptedJulesKey.mockResolvedValue('test-key');
+      julesApi.listJulesSessions.mockResolvedValue(mockSessions);
+      julesKeys.checkJulesKey.mockResolvedValue(true);
+
+      // Initialize the profile modal which attaches handlers
+      showUserProfileModal();
+
+      const viewAllLink = document.getElementById('viewAllSessionsLink');
+      const historyModal = document.getElementById('julesSessionsHistoryModal');
+
+      // Click the link
+      if (viewAllLink) viewAllLink.click();
+
+      // Check modal is shown
+      expect(historyModal.classList.contains('show')).toBe(true);
+
+      // Check sessions are loaded
+      await new Promise(resolve => setTimeout(resolve, 0)); // wait for async
+      expect(julesApi.listJulesSessions).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
This change internalizes the `showJulesSessionsHistoryModal` function within `src/modules/jules-account.js` as it is not used externally. It also refactors the event handler attachment logic to be more robust for testing (removing the one-time attachment flag) and adds a specific test case to verify the modal's functionality.

---
*PR created automatically by Jules for task [5457730975271461459](https://jules.google.com/task/5457730975271461459) started by @dogi*