### PR TITLE
jules api key fix (fixes #740)

### DIFF
--- a/src/modules/jules-keys.js
+++ b/src/modules/jules-keys.js
@@ -36,6 +36,9 @@ export async function deleteStoredJulesKey(uid) {
   try {
     const db = getDb();
     if (!db) return false;
+    
+    // Clear both session cache and memory cache
+    clearJulesKeyCache(uid);
     await deleteDoc('julesKeys', uid, CACHE_KEY);
     return true;
   } catch (error) {
@@ -45,6 +48,9 @@ export async function deleteStoredJulesKey(uid) {
 
 export async function encryptAndStoreKey(plaintext, uid) {
   try {
+    // Clear caches before encrypting to prevent stale data
+    clearJulesKeyCache(uid);
+    
     // Generate random salt and IV
     const salt = window.crypto.getRandomValues(new Uint8Array(16));
     const iv = window.crypto.getRandomValues(new Uint8Array(12));

--- a/src/pages/profile-page.js
+++ b/src/pages/profile-page.js
@@ -457,9 +457,9 @@ async function initApp() {
       addJulesKeyBtn.addEventListener('click', () => {
         showJulesKeyModal(() => {
           // Reload Jules key status after saving
+          // Note: showToast is already called by jules-modal.js
           if (currentUser) {
             loadJulesKeyStatus(currentUser);
-            showToast('Jules API key saved successfully', 'success');
           }
         });
       });


### PR DESCRIPTION
Fixed Jules API key issues by clearing both memory and session caches when keys are added, deleted, or migrated to prevent stale encrypted data from causing decryption failures after a day.

To test, add a Jules API key on the profile page, verify you only see one success toast (not two), then use Jules features like queue or sessions to confirm the key works persistently without needing to be re-added.