### PR TITLE
🧪 Improve slugify robustness and test coverage

### DIFF
--- a/src/unit-tests/utils/slug.test.js
+++ b/src/unit-tests/utils/slug.test.js
@@ -19,11 +19,31 @@ describe('slug.js', () => {
         // Based on regex /\.md$/i, if no .md, it just lowercases and slugifies
         expect(slugify('My File')).toBe('my-file');
     });
+
+    it('should return empty string for null or undefined', () => {
+        expect(slugify(null)).toBe('');
+        expect(slugify(undefined)).toBe('');
+    });
+
+    it('should return empty string for non-string inputs', () => {
+        expect(slugify(123)).toBe('');
+        expect(slugify({})).toBe('');
+    });
   });
 
   describe('unslugify', () => {
     it('should decode slug', () => {
-      expect(unslugify('hello-world%3F')).toBe('hello-world?');
+        expect(unslugify('hello-world%3F')).toBe('hello-world?');
+    });
+
+    it('should return empty string for null or undefined', () => {
+        expect(unslugify(null)).toBe('');
+        expect(unslugify(undefined)).toBe('');
+    });
+
+    it('should return empty string for non-string inputs', () => {
+        expect(unslugify(123)).toBe('');
+        expect(unslugify({})).toBe('');
     });
   });
 });

--- a/src/utils/slug.js
+++ b/src/utils/slug.js
@@ -1,10 +1,12 @@
 // ===== Slug Generation =====
 
 export function slugify(filePath) {
+  if (typeof filePath !== 'string') return '';
   const base = filePath.replace(/\.md$/i, '').toLowerCase().replace(/\s+/g, '-');
   return encodeURIComponent(base);
 }
 
 export function unslugify(slug) {
+  if (typeof slug !== 'string') return '';
   return decodeURIComponent(slug);
 }


### PR DESCRIPTION
🎯 **What:** The `slugify` and `unslugify` utilities were susceptible to throwing `TypeError` when passed non-string inputs such as `null` or `undefined`.

📊 **Coverage:** Added new test cases in `src/unit-tests/utils/slug.test.js` covering `null`, `undefined`, numbers, and objects for both functions.

✨ **Result:** Both functions now include type guards and return an empty string for any non-string input, significantly improving the application's reliability when handling dynamic file paths or URL parameters.

---
*PR created automatically by Jules for task [7387392099210168470](https://jules.google.com/task/7387392099210168470) started by @dogi*