### PR TITLE
🧹 refactor: convert initializeEditRepoAndBranch to use options object

### DIFF
--- a/src/modules/jules-queue.js
+++ b/src/modules/jules-queue.js
@@ -226,7 +226,7 @@ export function attachQueueHandlers() {
   setupQueueHandlers();
 }
 
-async function initializeEditRepoAndBranch(sourceId, branch, repoDropdownBtn, repoDropdownText, repoDropdownMenu, branchDropdownBtn, branchDropdownText, branchDropdownMenu) {
+async function initializeEditRepoAndBranch({ sourceId, branch, repoDropdownBtn, repoDropdownText, repoDropdownMenu, branchDropdownBtn, branchDropdownText, branchDropdownMenu }) {
   const editModalState = getEditModalState();
   
   const branchSelector = new BranchSelector({
@@ -598,7 +598,16 @@ async function openEditQueueModal(docId) {
 
   displayScheduleStatus(item);
 
-  await initializeEditRepoAndBranch(item.sourceId, item.branch || 'master', repoDropdownBtn, repoDropdownText, repoDropdownMenu, branchDropdownBtn, branchDropdownText, branchDropdownMenu);
+  await initializeEditRepoAndBranch({
+    sourceId: item.sourceId,
+    branch: item.branch || 'master',
+    repoDropdownBtn,
+    repoDropdownText,
+    repoDropdownMenu,
+    branchDropdownBtn,
+    branchDropdownText,
+    branchDropdownMenu
+  });
 
   updateEditModalState({ isInitializing: false });
 


### PR DESCRIPTION
🎯 **What:** Refactored `initializeEditRepoAndBranch` in `src/modules/jules-queue.js` to accept a single options object rather than 8 positional arguments.
💡 **Why:** Having 8 positional arguments makes the function difficult to read, maintain, and prone to errors if the order of arguments gets mixed up during a call. Passing an options object instead is cleaner and makes the argument intent clearer.
✅ **Verification:** Verified by ensuring the single usage of `initializeEditRepoAndBranch` in the same file was correctly updated to pass the destructured options object and running all existing unit tests in the test suite using `npm run test:run`, all of which passed.
✨ **Result:** A much cleaner, robust, and readable function signature that conforms with best practices for functions requiring multiple parameters.

---
*PR created automatically by Jules for task [4638907624318049550](https://jules.google.com/task/4638907624318049550) started by @dogi*