### PR TITLE
🧪 Add unit tests for clearCopenOptionsCache in copen-config.js

### DIFF
--- a/src/unit-tests/utils/copen-config.test.js
+++ b/src/unit-tests/utils/copen-config.test.js
@@ -186,4 +186,28 @@ describe('copen-config', () => {
       expect(options.find(o => o.value === 'default2')).toBeUndefined();
     });
   });
+
+  describe('clearCopenOptionsCache', () => {
+    it('should clear the cache and force a refetch on next call', async () => {
+      mockGetAuth.mockReturnValue({ currentUser: { uid: 'user123' } });
+      mockGetUserCopens.mockResolvedValue([
+        { id: 'blank', label: 'Blank', icon: 'public', isDefault: true }
+      ]);
+
+      // Call once to populate cache
+      await getCopenOptions();
+      expect(mockGetUserCopens).toHaveBeenCalledTimes(1);
+
+      // Call again to verify cache is used (should not call getUserCopens again)
+      await getCopenOptions();
+      expect(mockGetUserCopens).toHaveBeenCalledTimes(1);
+
+      // Clear the cache
+      clearCopenOptionsCache();
+
+      // Call again to verify cache is cleared (should call getUserCopens again)
+      await getCopenOptions();
+      expect(mockGetUserCopens).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap for `clearCopenOptionsCache` in `src/utils/copen-config.js` is addressed by adding unit tests.
📊 **Coverage:** The scenarios now tested include testing the initial populating of the cache, verifying that the cache is used on subsequent calls (without fetching anew), and verifying that calling `clearCopenOptionsCache` actually clears the cache and forces a re-fetch of options the next time `getCopenOptions` is called.
✨ **Result:** A significant improvement in test coverage for the `copen-config` module, ensuring cache management works as intended.

---
*PR created automatically by Jules for task [1865945699970869068](https://jules.google.com/task/1865945699970869068) started by @dogi*