### PR TITLE
🧪 Add unit tests for firebase-service.js

### DIFF
--- a/src/modules/firebase-service.js
+++ b/src/modules/firebase-service.js
@@ -72,3 +72,14 @@ export function onFirebaseReady(callback) {
     readyCallbacks.push(callback);
   }
 }
+
+/**
+ * Reset the Firebase services (mainly for testing)
+ */
+export function resetServices() {
+  authInstance = null;
+  dbInstance = null;
+  functionsInstance = null;
+  readyCallbacks = [];
+  isReady = false;
+}

--- a/src/unit-tests/modules/firebase-service.test.js
+++ b/src/unit-tests/modules/firebase-service.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  initServices,
+  getAuth,
+  getDb,
+  getFunctions,
+  onFirebaseReady,
+  resetServices
+} from '../../modules/firebase-service.js';
+
+describe('firebase-service', () => {
+  beforeEach(() => {
+    resetServices();
+  });
+
+  describe('initialization and getters', () => {
+    it('should return null for services before initialization', () => {
+      const auth = getAuth();
+      const db = getDb();
+      const functions = getFunctions();
+
+      expect(auth).toBeNull();
+      expect(db).toBeNull();
+      expect(functions).toBeNull();
+    });
+
+    it('should warn when accessing Auth or DB before initialization', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      getAuth();
+      expect(warnSpy).toHaveBeenCalledWith('Firebase Auth accessed before initialization');
+
+      getDb();
+      expect(warnSpy).toHaveBeenCalledWith('Firebase DB accessed before initialization');
+
+      warnSpy.mockRestore();
+    });
+
+    it('should initialize services and return them via getters', () => {
+      const mockAuth = { name: 'auth' };
+      const mockDb = { name: 'db' };
+      const mockFunctions = { name: 'functions' };
+
+      initServices(mockAuth, mockDb, mockFunctions);
+
+      expect(getAuth()).toBe(mockAuth);
+      expect(getDb()).toBe(mockDb);
+      expect(getFunctions()).toBe(mockFunctions);
+    });
+  });
+
+  describe('onFirebaseReady', () => {
+    it('should queue and execute callbacks after initialization', () => {
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      onFirebaseReady(callback1);
+      onFirebaseReady(callback2);
+
+      expect(callback1).not.toHaveBeenCalled();
+      expect(callback2).not.toHaveBeenCalled();
+
+      initServices({}, {}, {});
+
+      expect(callback1).toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalled();
+    });
+
+    it('should execute callback immediately if already ready', () => {
+      initServices({}, {}, {});
+      const callback = vi.fn();
+
+      onFirebaseReady(callback);
+
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should handle errors in callbacks and continue', () => {
+      const errorCallback = vi.fn(() => { throw new Error('Test Error'); });
+      const successCallback = vi.fn();
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      onFirebaseReady(errorCallback);
+      onFirebaseReady(successCallback);
+
+      initServices({}, {}, {});
+
+      expect(errorCallback).toHaveBeenCalled();
+      expect(successCallback).toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith('Error in firebase ready callback:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle errors in immediate callbacks', () => {
+      initServices({}, {}, {});
+      const errorCallback = vi.fn(() => { throw new Error('Immediate Test Error'); });
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      onFirebaseReady(errorCallback);
+
+      expect(errorCallback).toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith('Error in firebase ready callback:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
Implemented comprehensive unit tests for `src/modules/firebase-service.js` to address the missing test coverage. The tests verify service initialization, accessor logic, warning triggers when accessed prematurely, and the `onFirebaseReady` callback mechanism (including error resilience). To support clean testing, a `resetServices` function was added to the module. Verified the tests pass in the local environment.

---
*PR created automatically by Jules for task [8266883337743622078](https://jules.google.com/task/8266883337743622078) started by @dogi*