### PR TITLE
🔒 Fix unsafe innerHTML assignment in ide-extension-page.js

### DIFF
--- a/src/pages/ide-extension-page.js
+++ b/src/pages/ide-extension-page.js
@@ -19,14 +19,27 @@ function initApp() {
     installBtn.dataset.bound = 'true';
     installBtn.addEventListener('click', () => {
       installBtn.disabled = true;
-      const originalLabel = installBtn.innerHTML;
-      installBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">hourglass_top</span> Opening Marketplace...';
+
+      const originalContent = Array.from(installBtn.childNodes);
+
+      const loadingIcon = document.createElement('span');
+      loadingIcon.className = 'icon icon-inline';
+      loadingIcon.setAttribute('aria-hidden', 'true');
+      loadingIcon.textContent = 'hourglass_top';
+
+      installBtn.replaceChildren(loadingIcon, document.createTextNode(' Opening Marketplace...'));
 
       window.open(VSCODE_EXTENSION_URL, '_blank', 'noopener');
 
-      installBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">check_circle</span> Marketplace opened';
+      const successIcon = document.createElement('span');
+      successIcon.className = 'icon icon-inline';
+      successIcon.setAttribute('aria-hidden', 'true');
+      successIcon.textContent = 'check_circle';
+
+      installBtn.replaceChildren(successIcon, document.createTextNode(' Marketplace opened'));
+
       setTimeout(() => {
-        installBtn.innerHTML = originalLabel;
+        installBtn.replaceChildren(...originalContent);
         installBtn.disabled = false;
       }, TIMEOUTS.actionFeedback);
     });

--- a/src/unit-tests/pages/ide-extension-page.test.js
+++ b/src/unit-tests/pages/ide-extension-page.test.js
@@ -29,20 +29,25 @@ describe('IDE Extension Page', () => {
 
     const originalHTML = installBtn.innerHTML;
 
+    // Mock window.open to check state during its execution
+    window.open.mockImplementation(() => {
+      expect(installBtn.textContent).toContain('Opening Marketplace...');
+      expect(installBtn.querySelector('.icon').textContent).toBe('hourglass_top');
+      return null;
+    });
+
     // Simulate click
     installBtn.click();
 
     // Should be disabled
     expect(installBtn.disabled).toBe(true);
 
-    // Should show "Opening Marketplace..."
-    expect(installBtn.textContent).toContain('Opening Marketplace...');
-    expect(installBtn.querySelector('.icon').textContent).toBe('hourglass_top');
-
     // window.open should have been called
     expect(window.open).toHaveBeenCalledWith(VSCODE_EXTENSION_URL, '_blank', 'noopener');
 
-    // Should show "Marketplace opened"
+    // Intermediate states are synchronous before/after window.open
+    // But since the test checks after click(), it sees the final synchronous state
+    // Which is "Marketplace opened"
     expect(installBtn.textContent).toContain('Marketplace opened');
     expect(installBtn.querySelector('.icon').textContent).toBe('check_circle');
 

--- a/src/unit-tests/pages/ide-extension-page.test.js
+++ b/src/unit-tests/pages/ide-extension-page.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TIMEOUTS, VSCODE_EXTENSION_URL } from '../../utils/constants.js';
+
+describe('IDE Extension Page', () => {
+  let installBtn;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <header></header>
+      <button id="installExtensionBtn">
+        <span class="icon icon-inline" aria-hidden="true">store</span> Install from VS Code Marketplace
+      </button>
+    `;
+    installBtn = document.getElementById('installExtensionBtn');
+    vi.useFakeTimers();
+    vi.stubGlobal('open', vi.fn());
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  it('should initialize and handle click on install button', async () => {
+    // Import the module to trigger initialization
+    await import('../../pages/ide-extension-page.js');
+
+    const originalHTML = installBtn.innerHTML;
+
+    // Simulate click
+    installBtn.click();
+
+    // Should be disabled
+    expect(installBtn.disabled).toBe(true);
+
+    // Should show "Opening Marketplace..."
+    expect(installBtn.textContent).toContain('Opening Marketplace...');
+    expect(installBtn.querySelector('.icon').textContent).toBe('hourglass_top');
+
+    // window.open should have been called
+    expect(window.open).toHaveBeenCalledWith(VSCODE_EXTENSION_URL, '_blank', 'noopener');
+
+    // Should show "Marketplace opened"
+    expect(installBtn.textContent).toContain('Marketplace opened');
+    expect(installBtn.querySelector('.icon').textContent).toBe('check_circle');
+
+    // Fast-forward time
+    vi.advanceTimersByTime(TIMEOUTS.actionFeedback);
+
+    // Should be re-enabled and restored
+    expect(installBtn.disabled).toBe(false);
+    expect(installBtn.innerHTML).toBe(originalHTML);
+  });
+});


### PR DESCRIPTION
This PR addresses a security vulnerability related to unsafe `innerHTML` assignment in the IDE extension page.

### 🎯 What:
Fixed a potential XSS vulnerability where `innerHTML` was used to update the content of the "Install" button.

### ⚠️ Risk:
Using `innerHTML` to set content, even if currently static, can lead to Cross-Site Scripting (XSS) if the content ever becomes dynamic or user-controlled.

### 🛡️ Solution:
Replaced `innerHTML` with safer DOM APIs:
- `document.createElement` for creating the icon elements.
- `document.createTextNode` for the button text.
- `Element.replaceChildren()` for updating the button's content safely and efficiently.
- Directly restoring original child nodes (`Array.from(installBtn.childNodes)`) to preserve the initial state securely.

Added a new unit test `src/unit-tests/pages/ide-extension-page.test.js` to ensure the fix works as expected and to catch any future regressions. Verified the fix visually using Playwright.

---
*PR created automatically by Jules for task [2839477362113314015](https://jules.google.com/task/2839477362113314015) started by @dogi*