### PR TITLE
🧹 [CSS Refactor] Remove deprecated custom property aliases and class

### DIFF
--- a/docs/COLOR_CONSOLIDATION_GAMEPLAN.md
+++ b/docs/COLOR_CONSOLIDATION_GAMEPLAN.md
@@ -173,7 +173,7 @@ Accent color variations scattered across files:
 - [ ] Replace any stragglers with appropriate CSS variables
 
 ### Phase 9: Remove Deprecated Aliases
-- [ ] Remove `--muted` alias (replace with `--text-muted`)
+- [x] Remove `--muted` alias (replace with `--text-muted`)
 - [ ] Remove `--warn` alias (replace with `--warning`)
 - [ ] Update any JavaScript files referencing old variable names
 - [ ] Test: Full site regression test

--- a/docs/UI_GUIDELINES.md
+++ b/docs/UI_GUIDELINES.md
@@ -59,8 +59,6 @@ Located in `base.css`:
 :root {
   /* Core Colors */
   --bg: #0a0e1a;
-  --card: #141829;
-  --muted: #8b94a8;
   --text: #f0f3f8;
   --accent: #4dd9ff;
   --accent-glow: #4dd9ff1a;
@@ -122,7 +120,6 @@ Located in `base.css`:
 
 ```css
 .text-center   /* text-align: center */
-.muted         /* color: var(--muted) */
 .font-16       /* font-size: 16px */
 .fw-600        /* font-weight: 600 */
 .small-text    /* font-size: 13px */

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     </aside>
 
     <main id="main" class="card pad-lg">
-      <div id="empty" class="panel text-center pad-xl muted hidden">
+      <div id="empty" class="panel text-center pad-xl muted-text hidden">
       </div>
       
       <!-- Free Input Section (shown in main area) -->

--- a/pages/analytics/analytics.html
+++ b/pages/analytics/analytics.html
@@ -72,7 +72,7 @@
               <span class="icon metric-card__icon" aria-hidden="true">fact_check</span>
               <span class="metric-card__label">
                 Total Sessions
-                <span class="icon icon-inline icon-sm muted" aria-hidden="true" title="Total number of Jules sessions tracked in this time period">info</span>
+                <span class="icon icon-inline icon-sm muted-text" aria-hidden="true" title="Total number of Jules sessions tracked in this time period">info</span>
               </span>
             </div>
             <div class="metric-card__value" id="totalSessionsValue">0</div>
@@ -83,7 +83,7 @@
               <span class="icon metric-card__icon" aria-hidden="true">check_circle</span>
               <span class="metric-card__label">
                 Completion Rate
-                <span class="icon icon-inline icon-sm muted" aria-hidden="true" title="Percentage of finished sessions that completed successfully">info</span>
+                <span class="icon icon-inline icon-sm muted-text" aria-hidden="true" title="Percentage of finished sessions that completed successfully">info</span>
               </span>
             </div>
             <div class="metric-card__value" id="successRateValue">0.0%</div>
@@ -94,11 +94,11 @@
               <span class="icon metric-card__icon" aria-hidden="true">merge</span>
               <span class="metric-card__label">
                 PRs Created
-                <span class="icon icon-inline icon-sm muted" aria-hidden="true" title="Number of sessions that resulted in GitHub pull requests">info</span>
+                <span class="icon icon-inline icon-sm muted-text" aria-hidden="true" title="Number of sessions that resulted in GitHub pull requests">info</span>
               </span>
             </div>
             <div class="metric-card__value" id="prsCreatedValue">0</div>
-            <div class="metric-card__subtitle muted" id="prRateValue">0.0% of sessions</div>
+            <div class="metric-card__subtitle muted-text" id="prRateValue">0.0% of sessions</div>
           </div>
 
           <div class="metric-card">
@@ -106,7 +106,7 @@
               <span class="icon metric-card__icon" aria-hidden="true">cancel</span>
               <span class="metric-card__label">
                 Failed Sessions
-                <span class="icon icon-inline icon-sm muted" aria-hidden="true" title="Number of sessions that encountered errors and failed to complete">info</span>
+                <span class="icon icon-inline icon-sm muted-text" aria-hidden="true" title="Number of sessions that encountered errors and failed to complete">info</span>
               </span>
             </div>
             <div class="metric-card__value" id="failedSessionsValue">0</div>
@@ -139,7 +139,7 @@
               Failure Analysis
             </h2>
             <div id="failureAnalysisContainer">
-              <p class="muted small-text text-center pad-lg">No failures recorded</p>
+              <p class="muted-text small-text text-center pad-lg">No failures recorded</p>
             </div>
           </div>
 
@@ -150,7 +150,7 @@
               Repository Performance
             </h2>
             <div id="repoPerformanceContainer" class="vlist">
-              <p class="muted small-text text-center pad-lg">No data available</p>
+              <p class="muted-text small-text text-center pad-lg">No data available</p>
             </div>
           </div>
 
@@ -161,7 +161,7 @@
               Recent Pull Requests
             </h2>
             <div id="recentPRsContainer" class="vlist">
-              <p class="muted small-text text-center pad-lg">No PRs created yet</p>
+              <p class="muted-text small-text text-center pad-lg">No PRs created yet</p>
             </div>
           </div>
         </div>

--- a/pages/sessions/sessions.html
+++ b/pages/sessions/sessions.html
@@ -42,12 +42,12 @@
       
       <!-- Loading Message -->
       <div id="sessionsLoading" class="panel text-center pad-xl hidden">
-        <div class="muted font-16">Loading sessions...</div>
+        <div class="muted-text font-16">Loading sessions...</div>
       </div>
       
       <!-- Not Signed In Message -->
       <div id="sessionsNotSignedIn" class="panel text-center pad-xl hidden">
-        <div class="muted font-16">Please sign in to view your sessions.</div>
+        <div class="muted-text font-16">Please sign in to view your sessions.</div>
       </div>
 
       <!-- Sessions List -->

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -41,15 +41,11 @@ body {
   --surface-elevated: #1a1f35;     /* Hover/elevated states */
   --border: #222438;
   
-  /* Legacy aliases (deprecated - remove in future) */
-  --card: var(--surface);
   
   /* ===== TEXT ===== */
   --text: #f0f3f8;
   --text-muted: #8b94a8;
   
-  /* Legacy alias (deprecated - remove in future) */
-  --muted: var(--text-muted);
   
   /* ===== ACCENT (CYAN) ===== */
   --accent: #4dd9ff;

--- a/src/styles/components/content.css
+++ b/src/styles/components/content.css
@@ -157,7 +157,6 @@ a:hover { text-decoration: underline; }
 .pad-lg { padding:24px; }
 .pad-xl { padding:48px; }
 .hidden-initially { display:none; }
-.muted { color:var(--text-muted); }
 .font-16 { font-size:16px; }
 .font-48 { font-size:48px; }
 .fw-600 { font-weight:600; }


### PR DESCRIPTION
🎯 **What:** Removed deprecated CSS custom properties `--card` and `--muted` from `src/styles/base.css`. Updated all codebase references from the proxy class `.muted` to `.muted-text`.

💡 **Why:** These legacy CSS aliases were marked for removal. Doing so reduces redundancy and unifies the color definitions in the application under consistent naming conventions (e.g., `--text-muted`). 

✅ **Verification:** 
- Verified that `--card` and `--muted` are completely removed via search operations.
- Checked usages of the `.muted` CSS class and updated them to `.muted-text`.
- Ran tests suite (`npm run test:run`) and verified 982 passing tests.
- Reverted unintentional modifications to `vscode-extension` code that was erroneously touched via `sed` replace logic.

✨ **Result:** Cleaned up code structure, improving CSS maintainability and keeping styling strictly aligned with current UI variables.

---
*PR created automatically by Jules for task [11937350194199586742](https://jules.google.com/task/11937350194199586742) started by @dogi*