### PR TITLE
🧹 Remove duplicated color-error CSS rule

### DIFF
--- a/src/styles/components/utilities.css
+++ b/src/styles/components/utilities.css
@@ -46,9 +46,6 @@
 .color-warning { color: var(--warning); }
 .color-info { color: var(--info); }
 
-/* Legacy aliases */
-.color-error { color: var(--danger); }
-
 /* Backgrounds */
 .bg-subtle { background: var(--overlay-subtle); }
 .bg-hover { background: var(--overlay-hover); }


### PR DESCRIPTION
🎯 **What:** Removed duplicate `.color-error` CSS rule from `src/styles/components/utilities.css`.
💡 **Why:** To improve code maintainability and eliminate redundant CSS declarations. The `color-error` class is already defined as a legacy alias in `src/styles/base.css`.
✅ **Verification:** Verified that `.color-error` correctly maps to `var(--danger)` visually and runs via `npm run test:run` without regressions.
✨ **Result:** Cleaner utility CSS file with preserved functionality.

---
*PR created automatically by Jules for task [13486247442060220675](https://jules.google.com/task/13486247442060220675) started by @dogi*