### PR TITLE
🧪 [testing improvement] Add edge case tests for Owner Validation

### DIFF
--- a/src/unit-tests/utils/validation.test.js
+++ b/src/unit-tests/utils/validation.test.js
@@ -13,6 +13,8 @@ describe('validation.js', () => {
       expect(validateOwner('')).toBe(false);
       expect(validateOwner('-start')).toBe(false);
       expect(validateOwner('end-')).toBe(false);
+      expect(validateOwner('-')).toBe(false);
+      expect(validateOwner('a--b')).toBe(false);
       expect(validateOwner('double--hyphen')).toBe(false);
       expect(validateOwner('invalid char')).toBe(false);
       expect(validateOwner('a'.repeat(40))).toBe(false);


### PR DESCRIPTION
🎯 **What:** The testing gap for Owner Validation in `src/utils/validation.js` has been addressed. Specifically, the `validateOwner` function lacks explicit test cases for edge cases such as single hyphens and consecutive hyphens (e.g., 'a--b').

📊 **Coverage:** The unit tests in `src/unit-tests/utils/validation.test.js` have been updated to explicitly check these scenarios. Specifically, tests have been added to ensure that `validateOwner` returns `false` when given a single hyphen (`'-'`) or a string with consecutive hyphens (`'a--b'`).

✨ **Result:** Test coverage for `validateOwner` is now complete regarding the specified edge cases in the code comments and regex ("Cannot start or end with a hyphen, and no consecutive hyphens"). This improvement in test coverage provides a stronger safety net against future regressions.

---
*PR created automatically by Jules for task [1635257098973074221](https://jules.google.com/task/1635257098973074221) started by @dogi*