### PR TITLE
🔒 Fix XSS vulnerability by removing innerHTML usage in webcapture page

### DIFF
--- a/src/pages/webcapture-page.js
+++ b/src/pages/webcapture-page.js
@@ -6,6 +6,14 @@
 import { TIMEOUTS, WEB_CAPTURE_EXTENSION_URL } from '../utils/constants.js';
 import { detectExtension, isChromium } from '../utils/extension-detector.js';
 
+function setButtonContent(btn, iconName, text) {
+  const iconSpan = document.createElement('span');
+  iconSpan.className = 'icon icon-inline';
+  iconSpan.setAttribute('aria-hidden', 'true');
+  iconSpan.textContent = iconName;
+  btn.replaceChildren(iconSpan, document.createTextNode(' ' + text));
+}
+
 function waitForComponents() {
   if (document.querySelector('header')) {
     initApp();
@@ -26,21 +34,22 @@ async function initApp() {
     downloadBtn.addEventListener('click', async () => {
       try {
         downloadBtn.disabled = true;
-        const originalDownloadLabel = downloadBtn.innerHTML;
-        downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">hourglass_top</span> Opening Chrome Web Store...';
+        const originalNodes = Array.from(downloadBtn.childNodes).map(n => n.cloneNode(true));
+
+        setButtonContent(downloadBtn, 'hourglass_top', 'Opening Chrome Web Store...');
 
         window.open(WEB_CAPTURE_EXTENSION_URL, '_blank', 'noopener');
 
-        downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">check_circle</span> Store opened';
+        setButtonContent(downloadBtn, 'check_circle', 'Store opened');
         setTimeout(() => {
-          downloadBtn.innerHTML = originalDownloadLabel;
+          downloadBtn.replaceChildren(...originalNodes.map(n => n.cloneNode(true)));
           downloadBtn.disabled = false;
         }, TIMEOUTS.actionFeedback);
       } catch (error) {
         console.error('Store link failed:', error);
-        downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">error</span> Unable to open store';
+        setButtonContent(downloadBtn, 'error', 'Unable to open store');
         setTimeout(() => {
-          downloadBtn.innerHTML = originalDownloadLabel;
+          downloadBtn.replaceChildren(...originalNodes.map(n => n.cloneNode(true)));
           downloadBtn.disabled = false;
         }, TIMEOUTS.actionFeedback);
       }
@@ -55,7 +64,7 @@ async function checkExtensionStatus() {
   const isInstalled = await detectExtension();
 
   if (isInstalled) {
-    downloadBtn.innerHTML = '<span class="icon icon-inline" aria-hidden="true">store</span> View in Chrome Web Store';
+    setButtonContent(downloadBtn, 'store', 'View in Chrome Web Store');
   }
 }
 


### PR DESCRIPTION
🎯 **What:** Fixed an XSS vulnerability caused by using `innerHTML` to update the `downloadExtensionBtn` component in `src/pages/webcapture-page.js`.
⚠️ **Risk:** Although the current data assigned to `innerHTML` is static, maintaining `innerHTML` opens up the application to DOM-based Cross-Site Scripting (XSS) if user input or dynamic values were ever introduced into the content strings, allowing malicious script execution.
🛡️ **Solution:** Replaced `innerHTML` usage with a new `setButtonContent` helper function that safely constructs the UI using strictly secure DOM APIs (`document.createElement`, `textContent`, `document.createTextNode`, and `replaceChildren`). Original button state is securely preserved and restored by cloning `childNodes` instead of reading and writing raw HTML strings.

---
*PR created automatically by Jules for task [11152233971215426843](https://jules.google.com/task/11152233971215426843) started by @dogi*