### PR TITLE
🔒 Fix XSS vulnerability via unsafe innerHTML in extension popup

### DIFF
--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -20,16 +20,32 @@ if (!iconHelpers) {
 
 const { createIcon, createIconWithText, ICONS } = iconHelpers;
 
-const originalSyncLabel = syncBtn.innerHTML;
+function setButtonContent(btn, iconName, text, iconOptions = { size: 'inline' }) {
+  btn.replaceChildren();
+  btn.insertAdjacentHTML('beforeend', createIcon(iconName, iconOptions));
+  if (text) {
+    btn.appendChild(document.createTextNode(' ' + text));
+  }
+}
+
+function restoreSyncButton() {
+  syncBtn.replaceChildren();
+  const img = document.createElement('img');
+  img.src = 'PromptRootLogo.svg';
+  img.alt = '';
+  img.className = 'button-icon';
+  syncBtn.appendChild(img);
+  syncBtn.appendChild(document.createTextNode('Send to PromptRoot'));
+}
 
 function setDownloadButtonIdle() {
-  downloadBtn.innerHTML = createIconWithText(ICONS.DOWNLOAD, 'Download');
+  setButtonContent(downloadBtn, ICONS.DOWNLOAD, 'Download');
 }
 
 async function init() {
   await updateGitHubStatus();
-  connectGitHubBtn.innerHTML = createIconWithText(ICONS.LINK, 'Connect to GitHub');
-  disconnectBtn.innerHTML = createIcon(ICONS.LOGOUT, { title: 'Disconnect' });
+  setButtonContent(connectGitHubBtn, ICONS.LINK, 'Connect to GitHub');
+  setButtonContent(disconnectBtn, ICONS.LOGOUT, '', { title: 'Disconnect' });
   disconnectBtn.title = 'Disconnect';
   setDownloadButtonIdle();
   extractContent();
@@ -113,7 +129,7 @@ function downloadMarkdown() {
   const finalFilename = filename.endsWith('.md') ? filename : filename + '.md';
   
   downloadBtn.disabled = true;
-  downloadBtn.innerHTML = createIconWithText(ICONS.LOADING, 'Downloading...');
+  setButtonContent(downloadBtn, ICONS.LOADING, 'Downloading...');
   showStatus('Preparing download...', 'info');
   
   try {
@@ -155,7 +171,7 @@ async function syncToGitHub() {
   const finalFilename = filename.endsWith('.md') ? filename : filename + '.md';
   
   syncBtn.disabled = true;
-  syncBtn.innerHTML = createIconWithText(ICONS.LOADING, 'Sending...');
+  setButtonContent(syncBtn, ICONS.LOADING, 'Sending...');
   showStatus('Sending to PromptRoot...', 'info');
   
   try {
@@ -182,11 +198,11 @@ async function syncToGitHub() {
     }
     
     syncBtn.disabled = false;
-    syncBtn.innerHTML = originalSyncLabel;
+    restoreSyncButton();
   } catch (error) {
     showStatus('Error: ' + error.message, 'error');
     syncBtn.disabled = false;
-    syncBtn.innerHTML = originalSyncLabel;
+    restoreSyncButton();
   }
 }
 
@@ -290,7 +306,7 @@ function showStatus(message, type) {
   statusDiv.replaceChildren();
 
   const iconName = type === 'success' ? ICONS.CHECK : type === 'error' ? ICONS.ERROR : ICONS.INFO;
-  statusDiv.innerHTML = createIcon(iconName, { size: 'inline' });
+  statusDiv.insertAdjacentHTML('beforeend', createIcon(iconName, { size: 'inline' }));
   statusDiv.appendChild(document.createTextNode(' ' + message));
 
   statusDiv.className = `status ${type}`;

--- a/verify-extension.js
+++ b/verify-extension.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+
+const popupJs = fs.readFileSync('browser-extension/popup.js', 'utf8');
+
+if (popupJs.includes('innerHTML')) {
+    console.error('Failure: innerHTML still found in popup.js');
+    process.exit(1);
+}
+
+if (!popupJs.includes('function setButtonContent(btn, iconName, text, iconOptions = { size: \'inline\' })')) {
+    console.error('Failure: setButtonContent helper not found');
+    process.exit(1);
+}
+
+if (!popupJs.includes('function restoreSyncButton()')) {
+    console.error('Failure: restoreSyncButton helper not found');
+    process.exit(1);
+}
+
+console.log('Success: Extension source code manually verified.');


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The browser extension's `popup.js` script used `.innerHTML` to dynamically update button contents (e.g., "Connect to GitHub", "Downloading...", "Send to PromptRoot"). This poses an XSS risk.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could potentially exploit these `.innerHTML` assignments to inject malicious scripts into the extension context if unsanitized data (e.g., page title or URL) somehow makes its way into these values, leading to unauthorized access to the user's GitHub account and tokens.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced all 9 instances of `.innerHTML` assignment with safer DOM manipulation methods. Added a `setButtonContent` helper that uses `replaceChildren()`, `insertAdjacentHTML()` (only for static SVG icons), and `document.createTextNode()` to safely append dynamic or static text. The previous approach of caching raw HTML (`originalSyncLabel`) was also replaced with a structured DOM builder function (`restoreSyncButton()`). This aligns with Manifest V3 security best practices and project standards.

---
*PR created automatically by Jules for task [17926639683627792418](https://jules.google.com/task/17926639683627792418) started by @dogi*