### PR TITLE
🧪 add unit tests for clipboard utility

### DIFF
--- a/src/unit-tests/utils/clipboard.test.js
+++ b/src/unit-tests/utils/clipboard.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { copyText } from '../../utils/clipboard.js';
+
+describe('Clipboard Utilities', () => {
+  const originalClipboard = navigator.clipboard;
+  const originalExecCommand = document.execCommand;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock console.warn and console.error to keep test output clean
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true
+    });
+    document.execCommand = originalExecCommand;
+  });
+
+  it('should return false and warn if no text is provided', async () => {
+    const result = await copyText('');
+    expect(result).toBe(false);
+    expect(console.warn).toHaveBeenCalledWith('Clipboard: No text provided to copy.');
+  });
+
+  it('should use navigator.clipboard.writeText when available', async () => {
+    const mockWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      configurable: true
+    });
+
+    const result = await copyText('test text');
+
+    expect(result).toBe(true);
+    expect(mockWriteText).toHaveBeenCalledWith('test text');
+  });
+
+  it('should use document.execCommand fallback when navigator.clipboard is unavailable', async () => {
+    // Disable navigator.clipboard
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true
+    });
+
+    const mockExecCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = mockExecCommand;
+
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    const removeChildSpy = vi.spyOn(document.body, 'removeChild');
+
+    const result = await copyText('fallback text');
+
+    expect(result).toBe(true);
+    expect(mockExecCommand).toHaveBeenCalledWith('copy');
+    expect(appendChildSpy).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalled();
+
+    // Verify that a textarea was created with the correct value
+    const textarea = appendChildSpy.mock.calls[0][0];
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(textarea.value).toBe('fallback text');
+  });
+
+  it('should use document.execCommand fallback when navigator.clipboard.writeText is unavailable', async () => {
+    // navigator.clipboard exists but writeText doesn't
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {},
+      configurable: true
+    });
+
+    const mockExecCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = mockExecCommand;
+
+    const result = await copyText('fallback text 2');
+
+    expect(result).toBe(true);
+    expect(mockExecCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('should return false and log error when navigator.clipboard.writeText throws', async () => {
+    const error = new Error('Clipboard error');
+    const mockWriteText = vi.fn().mockRejectedValue(error);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      configurable: true
+    });
+
+    const result = await copyText('error text');
+
+    expect(result).toBe(false);
+    expect(console.error).toHaveBeenCalledWith('Clipboard copy failed:', error);
+  });
+
+  it('should return false when both navigator.clipboard and execCommand fail', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true
+    });
+
+    document.execCommand = vi.fn().mockReturnValue(false);
+
+    const result = await copyText('fail text');
+
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR adds a new test file `src/unit-tests/utils/clipboard.test.js` to provide unit test coverage for the `copyText` utility in `src/utils/clipboard.js`.

The tests cover:
- **Edge cases:** Ensuring empty or missing text returns `false` and logs a warning.
- **Happy path:** Verifying that the modern `navigator.clipboard.writeText` API is used when available.
- **Fallback path:** Ensuring that the utility correctly falls back to using a temporary `textarea` and `document.execCommand('copy')` when the modern API is unavailable (e.g., in non-secure contexts).
- **Error handling:** Verifying that errors during the copy process are caught, logged, and return `false`.

Due to `vitest` not being available in the immediate execution environment, the logic was verified using a standalone script that mocks the necessary browser globals. All tests passed correctly.

---
*PR created automatically by Jules for task [13801291587326712009](https://jules.google.com/task/13801291587326712009) started by @dogi*