### PR TITLE
🧪 test: add missing tests for clearPromptViewerHandlers

### DIFF
--- a/src/unit-tests/modules/jules-queue-store.test.js
+++ b/src/unit-tests/modules/jules-queue-store.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { clearPromptViewerHandlers, registerPromptViewerHandler } from '../../../src/modules/jules-queue-store.js';
+import * as handlerRegistry from '../../../src/utils/handler-registry.js';
+
+vi.mock('../../../src/utils/handler-registry.js', () => ({
+  clearHandlers: vi.fn(),
+  registerHandler: vi.fn()
+}));
+
+describe('jules-queue-store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('clearPromptViewerHandlers', () => {
+    it('should call clearHandlers with "queueViewer"', () => {
+      clearPromptViewerHandlers();
+      expect(handlerRegistry.clearHandlers).toHaveBeenCalledWith('queueViewer');
+      expect(handlerRegistry.clearHandlers).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('registerPromptViewerHandler', () => {
+    it('should call registerHandler with "queueViewer", key, and handler', () => {
+      const mockKey = 'testKey';
+      const mockHandler = vi.fn();
+
+      registerPromptViewerHandler(mockKey, mockHandler);
+
+      expect(handlerRegistry.registerHandler).toHaveBeenCalledWith('queueViewer', mockKey, mockHandler);
+      expect(handlerRegistry.registerHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
* 🎯 **What:** The testing gap for `clearPromptViewerHandlers` and `registerPromptViewerHandler` in `jules-queue-store` has been addressed.
* 📊 **Coverage:** The scenarios tested now cover both methods properly using mock functions to verify they successfully call out to the imported `handler-registry`.
* ✨ **Result:** Improved test coverage for `jules-queue-store`.

---
*PR created automatically by Jules for task [13184600236358633976](https://jules.google.com/task/13184600236358633976) started by @uj-sxn*