### PR TITLE
fix: update codex copen url

### DIFF
--- a/src/modules/copen-manager.js
+++ b/src/modules/copen-manager.js
@@ -8,7 +8,7 @@ import { getDb } from './firebase-service.js';
 const DEFAULT_COPENS = [
   { id: 'blank', label: 'Blank', icon: 'public', url: 'about:blank', isDefault: true },
   { id: 'claude', label: 'Claude', icon: 'smart_toy', url: 'https://claude.ai/code', isDefault: true },
-  { id: 'codex', label: 'Codex', icon: 'forum', url: 'https://chatgpt.com/codex', isDefault: true },
+  { id: 'codex', label: 'Codex', icon: 'forum', url: 'https://chatgpt.com/codex/cloud', isDefault: true },
   { id: 'copilot', label: 'Copilot', icon: 'code', url: 'https://github.com/copilot/agents', isDefault: true },
   { id: 'gemini', label: 'Gemini', icon: 'auto_awesome', url: 'https://gemini.google.com/app', isDefault: true },
   { id: 'chatgpt', label: 'ChatGPT', icon: 'chat', url: 'https://chatgpt.com/', isDefault: true }


### PR DESCRIPTION
Updates the codex URL in the copen manager from `https://chatgpt.com/codex` to `https://chatgpt.com/codex/cloud` to address issue #809. Tests have been run and verified.

---
*PR created automatically by Jules for task [4524993584359544523](https://jules.google.com/task/4524993584359544523) started by @dogi*