### PR TITLE
fix: serve app code network-first to avoid stale UI (#812)

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -87,9 +87,6 @@ const NETWORK_FIRST_PATTERNS = [
   /github\.com\/.*\/contents\//
 ];
 
-// Heavy third-party CDN deps that change rarely and dominate load time.
-// These keep cache-first; everything else (our own HTML/JS/CSS) is network-first
-// so navbar/UI updates ship without requiring a hard refresh.
 const CACHE_FIRST_PATTERNS = [
   /gstatic\.com\/firebasejs\//,
   /cdn\.jsdelivr\.net\//,
@@ -168,14 +165,11 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Cache-first only for heavy, rarely-changing CDN deps.
   if (CACHE_FIRST_PATTERNS.some(pattern => pattern.test(request.url))) {
     event.respondWith(cacheFirstStrategy(request));
     return;
   }
 
-  // Default: network-first for our own app code (HTML/JS/CSS) so updates
-  // appear immediately. Falls back to cache when offline.
   event.respondWith(networkFirstStrategy(request));
 });
 

--- a/sw.js
+++ b/sw.js
@@ -10,7 +10,7 @@
 // 5. SW broadcasts { type: 'SW_UPDATED' } to all clients (e.g. other tabs).
 // 6. Clients reload or show notification.
 
-const CACHE_VERSION = 'promptroot-v9';
+const CACHE_VERSION = 'promptroot-v10';
 const CACHE_NAME = `${CACHE_VERSION}-static`;
 const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
 
@@ -87,6 +87,16 @@ const NETWORK_FIRST_PATTERNS = [
   /github\.com\/.*\/contents\//
 ];
 
+// Heavy third-party CDN deps that change rarely and dominate load time.
+// These keep cache-first; everything else (our own HTML/JS/CSS) is network-first
+// so navbar/UI updates ship without requiring a hard refresh.
+const CACHE_FIRST_PATTERNS = [
+  /gstatic\.com\/firebasejs\//,
+  /cdn\.jsdelivr\.net\//,
+  /fonts\.googleapis\.com\//,
+  /fonts\.gstatic\.com\//
+];
+
 // Install event - cache critical static assets
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -157,9 +167,16 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(networkFirstStrategy(request));
     return;
   }
-  event.respondWith(
-    cacheFirstStrategy(request)
-  );
+
+  // Cache-first only for heavy, rarely-changing CDN deps.
+  if (CACHE_FIRST_PATTERNS.some(pattern => pattern.test(request.url))) {
+    event.respondWith(cacheFirstStrategy(request));
+    return;
+  }
+
+  // Default: network-first for our own app code (HTML/JS/CSS) so updates
+  // appear immediately. Falls back to cache when offline.
+  event.respondWith(networkFirstStrategy(request));
 });
 
 async function networkFirstStrategy(request) {


### PR DESCRIPTION
Closes #812

## Summary
- Default fetch strategy in `sw.js` is now **network-first** for our own HTML/JS/CSS, so UI changes (e.g. the new openclaw navbar tab) appear without requiring a hard refresh.
- **Cache-first** preserved for heavy third-party CDN deps that rarely change and dominate repeat-load perf: Firebase SDK, jsdelivr (marked, DOMPurify), Google Fonts.
- Bumped `CACHE_VERSION` to `promptroot-v10` so the new strategy activates for existing users.

## Why
Cache-first on app code meant any header/navbar/page change was invisible until `CACHE_VERSION` bumped and the user accepted the SW update. The UX cost was not worth the ~100ms of extra repeat-load speed on app code; we keep the bulk of the perf win by leaving the large CDN deps cache-first.

## Test plan
- [ ] Load site fresh, confirm everything still works
- [ ] Deploy a small visible change (e.g. nav text), confirm it appears on next navigation without hard refresh
- [ ] Go offline, confirm cached pages still render (network-first falls back to cache)
- [ ] Verify Firebase SDK / marked / DOMPurify still served from SW on repeat loads (DevTools > Network > "from ServiceWorker")

Generated with [Claude Code](https://claude.com/claude-code)