### PR TITLE
🧹 Remove unused variable `taskRegex`

### DIFF
--- a/src/modules/subtask-manager.js
+++ b/src/modules/subtask-manager.js
@@ -38,7 +38,6 @@ export function extractManualSplits(text) {
  */
 export function extractNumberedTasks(text) {
   const tasks = [];
-  const taskRegex = /^Task\s+(\d+):\s*(.+?)$/gim;
   const lines = text.split('\n');
   
   let currentTask = null;


### PR DESCRIPTION
🎯 **What:** Removed the unused `taskRegex` variable from `extractNumberedTasks` in `src/modules/subtask-manager.js`.
💡 **Why:** To improve code health and readability by removing dead code. 
✅ **Verification:** Ran `npm run test:run` and specifically tested `src/unit-tests/modules/subtask-manager.test.js` to ensure existing tests passed. Also used `cat` to verify the variable was successfully removed from the file.
✨ **Result:** Cleaned up unused variable with zero impact on functionality.

---
*PR created automatically by Jules for task [3595695687068767249](https://jules.google.com/task/3595695687068767249) started by @uj-sxn*