### PR TITLE
Fix Jules API run endpoint to prevent Failed to fetch errors (fixes #820)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -62,7 +62,7 @@
         "headers": [
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://unpkg.com https://www.gstatic.com https://apis.google.com; frame-src 'self' https://*.firebaseapp.com; connect-src 'self' https://api.github.com https://jules.googleapis.com https://*.googleapis.com https://*.firebaseio.com https://runjuleshttp-fjbc67s6eq-uc.a.run.app https://us-central1-promptroot-b02a2.cloudfunctions.net https://*.a.run.app https://raw.githubusercontent.com https://gist.githubusercontent.com https://cdn.jsdelivr.net https://www.gstatic.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'"
+            "value": "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://unpkg.com https://www.gstatic.com https://apis.google.com; frame-src 'self' https://*.firebaseapp.com; connect-src 'self' https://api.github.com https://jules.googleapis.com https://*.googleapis.com https://*.firebaseio.com https://us-central1-promptroot-b02a2.cloudfunctions.net https://*.a.run.app https://raw.githubusercontent.com https://gist.githubusercontent.com https://cdn.jsdelivr.net https://www.gstatic.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'"
           }
         ]
       },

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.gstatic.com https://apis.google.com; frame-src 'self' https://*.firebaseapp.com; connect-src 'self' https://api.github.com https://jules.googleapis.com https://*.googleapis.com https://*.firebaseio.com https://runjuleshttp-fjbc67s6eq-uc.a.run.app https://us-central1-promptroot-b02a2.cloudfunctions.net https://*.a.run.app https://raw.githubusercontent.com https://gist.githubusercontent.com https://cdn.jsdelivr.net https://www.gstatic.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net https://www.gstatic.com https://apis.google.com; frame-src 'self' https://*.firebaseapp.com; connect-src 'self' https://api.github.com https://jules.googleapis.com https://*.googleapis.com https://*.firebaseio.com https://us-central1-promptroot-b02a2.cloudfunctions.net https://*.a.run.app https://raw.githubusercontent.com https://gist.githubusercontent.com https://cdn.jsdelivr.net https://www.gstatic.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com" />
   <title>PromptRoot</title>
   <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
   

--- a/src/modules/jules-api.js
+++ b/src/modules/jules-api.js
@@ -217,7 +217,9 @@ export async function callRunJulesFunction(promptText, sourceId, branch = 'maste
 
 async function runJulesAPI(promptText, sourceId, branch, title, user) {
   const token = await user.getIdToken(true);
-  const functionUrl = 'https://runjuleshttp-fjbc67s6eq-uc.a.run.app';
+  const functionUrl = (typeof window !== 'undefined' && window.location && window.location.port === '5000')
+    ? `http://${window.location.hostname}:5001/promptroot-b02a2/us-central1/runJulesHttp`
+    : 'https://us-central1-promptroot-b02a2.cloudfunctions.net/runJulesHttp';
 
   // Normalize sourceId format - handle both "owner/repo" and "sources/github/owner/repo" formats
   let normalizedSourceId = sourceId;

--- a/src/tests/csp-config.test.js
+++ b/src/tests/csp-config.test.js
@@ -30,7 +30,6 @@ describe('Content Security Policy Configuration', () => {
     expect(csp).toContain("https://jules.googleapis.com");
     expect(csp).toContain("https://*.googleapis.com");
     expect(csp).toContain("https://*.firebaseio.com");
-    expect(csp).toContain("https://runjuleshttp-fjbc67s6eq-uc.a.run.app");
     expect(csp).toContain("https://raw.githubusercontent.com");
     expect(csp).toContain("https://gist.githubusercontent.com");
 


### PR DESCRIPTION
This patch resolves the "jules is broken" / `TypeError: Failed to fetch` error occurring in the `runJulesAPI` when a user attempts to run a Jules session.

- **URL Fix**: Changed the hardcoded gen2 `runjuleshttp-fjbc67s6eq-uc.a.run.app` URL to use standard Firebase Functions routing (`us-central1-promptroot-b02a2.cloudfunctions.net/runJulesHttp`) and included `localhost:5001` routing for emulator development (matching `agent-keys.js`).
- **CSP Updates**: Safely removed the legacy `.a.run.app` domain from the Content Security Policy inside `firebase.json` and `index.html`.
- **Test updates**: Removed the assertion checking for the old URL in `src/tests/csp-config.test.js`.
- All tests passing without regressions.

---
*PR created automatically by Jules for task [13808248791594327220](https://jules.google.com/task/13808248791594327220) started by @dogi*